### PR TITLE
API changes

### DIFF
--- a/src/Strs.jl
+++ b/src/Strs.jl
@@ -96,6 +96,7 @@ isdefined(Base, :Cvoid)          || (const Cvoid = Void)
 isdefined(Base, :AbstractChar)   || (abstract type AbstractChar end ; export AbstractChar)
 
 @static isdefined(Base, :codeunits) || include("codeunits.jl")
+@static isdefined(Base, :Fix2)      || include("fix2.jl")
 
 export find
 function fnd end
@@ -144,11 +145,13 @@ include("utf32.jl")
 include("search.jl")
 include("utf8search.jl")
 include("utf16search.jl")
+include("regex.jl")
 include("encode.jl")
 include("stats.jl")
 include("legacy.jl")
 include("utf8case.jl")
 include("utf16case.jl")
 include("util.jl")
+include("io.jl") 
 
 end # module Strs

--- a/src/Strs.jl
+++ b/src/Strs.jl
@@ -48,7 +48,9 @@ Note: for good substring performance, some of the operations that are optimized 
 # Convenience functions
 export to_ascii, utf8, utf16, utf32
 
-export unsafe_str, codeunit, codeunits, codepoints, @str_str, @condimport
+export unsafe_str, codeunit, codeunits, codepoints, @str_str
+
+export category_code, category_string, category_abbrev, is_mutable
 
 symstr(s...) = Symbol(string(s...))
 quotesym(s...) = Expr(:quote, symstr(s...))
@@ -57,44 +59,90 @@ macro str_str(string)
     :( unsafe_str($(esc(string))) )
 end
 
-"""Import the symbol from Base if defined, otherwise export it"""
-macro condimport(sym)
-    :( if isdefined(Base, $(quotesym(sym))) ; import Base: $sym ; else ; export $sym ; end )
-end        
-
-"""Import the symbol from module if defined, otherwise export it"""
-macro condimport(mod, sym)
-    :( if isdefined($mod, $(quotesym(sym))) ; import $mod: $sym ; else ; export $sym ; end )
-end
-
 using Base: @_inline_meta, @propagate_inbounds, @_propagate_inbounds_meta
 
 import Base: containsnul, convert, getindex, length, map, pointer, collect, in,
              reverse, rsearch, search, sizeof, string, unsafe_convert, unsafe_load, write,
              codeunit, start, next, done, nextind, prevind, reverseind,
-             typemin, typemax, isvalid, rem, size, ndims, first, last, eltype, isempty, in,
+             typemin, typemax, rem, size, ndims, first, last, eltype,
              isless, ==, -, +, *, ^, cmp, promote_rule, one, repeat, filter,
-             print, show, isimmutable, startswith, endswith, chop, chomp,
-             lstrip, rstrip, strip, lpad, rpad, split, rsplit, replace, ascii
-    
-@condimport ind2chr
-@condimport chr2ind
-@condimport thisind
-@condimport codeunits
-@condimport ncodeunits
-@condimport bytestring
-@condimport firstindex
-@condimport lastindex
-@condimport contains
-@condimport isfound
-@condimport codepoint
+             print, show, isimmutable, chop, chomp, replace, ascii,
+             lstrip, rstrip, strip, lpad, rpad, split, rsplit, uppercase, lowercase
 
-isdefined(Base, :copyto!)        || (const copyto! = copy!)
-isdefined(Base, :unsafe_copyto!) || (const unsafe_copyto! = unsafe_copy!)
-isdefined(Base, :Nothing)        || (const Nothing = Void)
-isdefined(Base, :Cvoid)          || (const Cvoid = Void)
-isdefined(Base, :AbstractChar)   || (abstract type AbstractChar end ; export AbstractChar)
+# Conditionally import names that are only in v0.6 or in master
+for sym in (:ind2chr, :chr2ind, :thisind, :codeunits, :ncodeunits, :bytestring, :firstindex,
+            :lastindex, :contains, :isfound, :codepoint, :Fix2)
+    if isdefined(Base, sym)
+        @eval import Base: $sym
+    else
+        @eval export $sym
+    end
+end
 
+# Possibly import functions, give new names with underscores
+
+for (oldname, newname) in ((:textwidth, :text_width),
+                           (:lowercasefirst, :lowercase_first),
+                           (:uppercasefirst, :uppercase_first),
+                           (:startswith, :starts_with),
+                           (:endswith, :ends_with))
+    if isdefined(Base, oldname)
+        @eval import Base: $oldname
+        @eval const $newname = $oldname
+    end
+    @eval export $newname
+end
+
+# Possibly import `is` functions, give more readable names starting with `is_`
+
+for (oldn, newn) in
+    [(:xdigit, :hex_digit), (:cntrl, :control), (:punct, :punctuation), (:print, :printable)]
+    oldname, newname = symstr("is",  oldn), symstr("is_", newn)
+    if isdefined(Base, oldname)
+        @eval import Base: $oldname
+        @eval const $newname = $oldname
+    end
+    @eval export $newname
+end
+
+# Handle renames where function was deprecated
+
+export is_alphanumeric, is_graphic, is_lowercase, is_uppercase
+@static if VERSION < v"0.7.0-DEV"
+    import Base: isalnum, isgraph, islower, isupper
+    const is_alphanumeric = isalnum
+    const is_graphic      = isgraph
+    const is_lowercase    = islower
+    const is_uppercase    = isupper
+else
+    import Base: islowercase, isuppercase
+    const is_lowercase = islowercase
+    const is_uppercase = isuppercase
+end
+
+# Possibly import `is` functions, rename to start with `is_`
+
+for nam in (:ascii, :digit, :space, :alpha, :numeric, :valid, :defined, :empty)
+    oldname, newname = symstr("is",  nam), symstr("is_", nam)
+    if isdefined(Base, oldname)
+        @eval import Base: $oldname
+        @eval const $newname = $oldname
+    end
+    @eval export $newname
+end
+
+# Location of isgraphemebreak moved from Base.UTF8proc to Base.Unicode,
+# import and add new names with underscores
+
+const unimod = @static isdefined(Base, :UTF8proc) ? :UTF8proc : :Unicode
+
+@eval import Base.$unimod: isgraphemebreak, isgraphemebreak!, graphemes
+export is_grapheme_break, is_grapheme_break!
+const is_grapheme_break  = isgraphemebreak
+const is_grapheme_break! = isgraphemebreak!
+
+@static VERSION < v"0.7.0-DEV" || import Base.GC: @preserve
+@static VERSION < v"0.7.0-DEV" && include("compat.jl")
 @static isdefined(Base, :codeunits) || include("codeunits.jl")
 @static isdefined(Base, :Fix2)      || include("fix2.jl")
 
@@ -102,35 +150,17 @@ export find
 function fnd end
 const find = fnd
 
+# Handle changes in array allocation
 create_vector(T, len)  = @static VERSION < v"0.7.0-DEV" ? Vector{T}(len) : Vector{T}(undef, len)
-outhex(v, p=1) = @static VERSION < v"0.7.0-DEV" ? hex(v,p) : string(v, base=16, pad=p)
 
-@static if VERSION < v"0.7.0-DEV"
-macro preserve(args...)
-    syms = args[1:end-1]
-    for x in syms
-        isa(x, Symbol) || error("Preserved variable must be a symbol")
-    end
-    #=
-    s, r = gensym(), gensym()
-    esc(quote
-        $s = $(Expr(:gc_preserve_begin, syms...))
-        $r = $(args[end])
-        $(Expr(:gc_preserve_end, s))
-        $r
-        $(args[end])
-    end)
-    =#
-    esc(quote ; $(args[end]) ; end)
-end
-else
-    import Base.GC: @preserve
-end
+# Add new short name for deprecated hex function
+outhex(v, p=1) = @static VERSION < v"0.7.0-DEV" ? hex(v,p) : string(v, base=16, pad=p)
 
 include("types.jl")
 include("chars.jl")
 include("access.jl")
 include("traits.jl")
+include("utf8proc.jl")
 include("unicode.jl")
 include("casefold.jl")
 include("iters.jl")

--- a/src/Strs.jl
+++ b/src/Strs.jl
@@ -97,6 +97,10 @@ isdefined(Base, :AbstractChar)   || (abstract type AbstractChar end ; export Abs
 
 @static isdefined(Base, :codeunits) || include("codeunits.jl")
 
+export find
+function fnd end
+const find = fnd
+
 create_vector(T, len)  = @static VERSION < v"0.7.0-DEV" ? Vector{T}(len) : Vector{T}(undef, len)
 outhex(v, p=1) = @static VERSION < v"0.7.0-DEV" ? hex(v,p) : string(v, base=16, pad=p)
 

--- a/src/Strs.jl
+++ b/src/Strs.jl
@@ -74,7 +74,8 @@ import Base: containsnul, convert, getindex, length, map, pointer, collect, in,
              codeunit, start, next, done, nextind, prevind, reverseind,
              typemin, typemax, isvalid, rem, size, ndims, first, last, eltype, isempty, in,
              isless, ==, -, +, *, ^, cmp, promote_rule, one, repeat, filter,
-             print, show, isimmutable
+             print, show, isimmutable, startswith, endswith, chop, chomp,
+             lstrip, rstrip, strip, lpad, rpad, split, rsplit, replace, ascii
     
 @condimport ind2chr
 @condimport chr2ind
@@ -144,8 +145,6 @@ include("stats.jl")
 include("legacy.jl")
 include("utf8case.jl")
 include("utf16case.jl")
-#include("util.jl")
-#include("substring.jl")
-#include("io.jl")
+include("util.jl")
 
 end # module Strs

--- a/src/ascii.jl
+++ b/src/ascii.jl
@@ -27,12 +27,6 @@ end
 
 string(c::Str{ASCIICSE}...) = length(c) == 1 ? c[1] : Str(ASCIICSE, _string(c))
 
-## outputting ASCII strings ##
-
-write(io::IO, s::Str{ASCIICSE,Nothing}) = write(io, s.data)
-
-write(io::IO, ch::ASCIIChr) = write(io, tobase(ch))
-
 ## transcoding to ASCII ##
 
 function convert(::Type{ASCIIStr}, str::AbstractString)

--- a/src/casefold.jl
+++ b/src/casefold.jl
@@ -8,9 +8,9 @@ Licensed under MIT License, see LICENSE.md
 _lowercase_l(ch) = ifelse(_isupper_al(ch), ch + 0x20, ch)
 _uppercase_l(ch) = ifelse(_can_upper(ch),  ch - 0x20, ch)
 
-_lowercase(ch) = islatin(ch) ? _lowercase_l(ch) : _lowercase_u(ch)
-_uppercase(ch) = islatin(ch) ? _uppercase_l(ch) : _uppercase_u(ch)
-_titlecase(ch) = islatin(ch) ? _uppercase_l(ch) : _titlecase_u(ch)
+_lowercase(ch) = is_latin(ch) ? _lowercase_l(ch) : _lowercase_u(ch)
+_uppercase(ch) = is_latin(ch) ? _uppercase_l(ch) : _uppercase_u(ch)
+_titlecase(ch) = is_latin(ch) ? _uppercase_l(ch) : _titlecase_u(ch)
 
 lowercase(ch::T) where {T<:CodePointTypes} = T(_lowercase(tobase(ch)))
 uppercase(ch::T) where {T<:CodePointTypes} = T(_uppercase(tobase(ch)))
@@ -20,7 +20,7 @@ lowercase(ch::ASCIIChr) = ifelse(isupper(ch), ASCIIChr(ch + 0x20), ch)
 uppercase(ch::ASCIIChr) = ifelse(islower(ch), ASCIIChr(ch - 0x20), ch)
 titlecase(ch::ASCIIChr) = uppercase(ch)
 
-function ucfirst(str::ASCIIStr)
+function uppercase_first(str::ASCIIStr)
     (len = _len(str)) == 0 && return str
     pnt = _pnt(str)
     ch = get_codeunit(pnt)
@@ -31,7 +31,7 @@ function ucfirst(str::ASCIIStr)
     Str(ASCIICSE, out)
 end
 
-function lcfirst(str::ASCIIStr)
+function lowercase_first(str::ASCIIStr)
     (len = _len(str)) == 0 && return str
     pnt = _pnt(str)
     ch = get_codeunit(pnt)
@@ -103,7 +103,7 @@ function lowercase(str::ASCIIStr)
     str
 end
 
-function ucfirst(str::LatinStr)
+function uppercase_first(str::LatinStr)
     (len = _len(str)) == 0 && return str
     pnt = _pnt(str)
     ch = get_codeunit(pnt)
@@ -115,7 +115,7 @@ function ucfirst(str::LatinStr)
 end
 
 # Special handling for characters that can't map into Latin1
-function ucfirst(str::_LatinStr)
+function uppercase_first(str::_LatinStr)
     (len = _len(str)) == 0 && return str
     pnt = _pnt(str)
     ch = get_codeunit(pnt)
@@ -137,7 +137,7 @@ function ucfirst(str::_LatinStr)
     end
 end
 
-function lcfirst(str::T) where {T<:LatinStrings}
+function lowercase_first(str::T) where {T<:LatinStrings}
     (len = _len(str)) == 0 && return str
     pnt = _pnt(str)
     ch = get_codeunit(pnt)
@@ -291,7 +291,7 @@ function _lower(::Type{T}, beg, off, len) where {T<:_UCS2Str}
         end
         out += sizeof(CU)
     end
-    if flg && islatin(buf)
+    if flg && is_latin(buf)
         out = pointer(buf)
         buf = _allocate(len)
         _narrow!(pointer(buf), out, out + len)

--- a/src/chars.jl
+++ b/src/chars.jl
@@ -6,14 +6,16 @@ Licensed under MIT License, see LICENSE.md
 In part based on code for Char in Julia
 =#
 
-"""Default value for Str types"""
-codeunit(::Type{<:Str}) = UInt8
+"""Default value for Str /CodePoint types"""
+codeunit(::Type{<:CSE}) = UInt8
+codeunit(::Type{<:Word_CSEs}) = UInt16
+codeunit(::Type{<:Quad_CSEs}) = UInt32
+
 ncodeunits(str::T) where {T<:Str} = _len(str)
 
 """Type of codeunits"""
-codeunit(::Type{<:WordStr}) = UInt16
-codeunit(::Type{<:QuadStr}) = UInt32
 codeunit(::Type{UniStr})    = UInt32 # Note, the real type could be UInt8, UInt16, or UInt32
+codeunit(::Type{<:Str{C}}) where {C<:CSE} = codeunit(C)
 
 codeunit(::S) where {S<:Str} = codeunit(S)
 

--- a/src/compat.jl
+++ b/src/compat.jl
@@ -1,0 +1,38 @@
+# Handle some name changes between v0.6 and master   
+const copyto! = copy!
+const unsafe_copyto! = unsafe_copy!
+const Nothing = Void
+const Cvoid = Void
+abstract type AbstractChar end
+export AbstractChar
+
+export StringIndexError
+struct StringIndexError <: Exception
+    string::AbstractString
+    index::Integer
+end
+@noinline index_error(s::AbstractString, i::Integer) = throw(StringIndexError(s, Int(i)))
+
+function thisind(str::String, pos::Integer)
+    @boundscheck 0 < pos <= _len(str) || boundserr(str, pos)
+    pnt = _pnt(str) + pos - 1
+    pos - (checkcont(pnt) ? (checkcont(pnt - 1) ? (checkcont(pnt - 2) ? 3 : 2) : 1) : 0)
+end
+
+macro preserve(args...)
+    syms = args[1:end-1]
+    for x in syms
+        isa(x, Symbol) || error("Preserved variable must be a symbol")
+    end
+    #=
+    s, r = gensym(), gensym()
+    esc(quote
+        $s = $(Expr(:gc_preserve_begin, syms...))
+        $r = $(args[end])
+        $(Expr(:gc_preserve_end, s))
+        $r
+        $(args[end])
+    end)
+    =#
+    esc(quote ; $(args[end]) ; end)
+end

--- a/src/core.jl
+++ b/src/core.jl
@@ -189,8 +189,6 @@ print(io::IO, str::Union{T,SubString{T}}) where {T<:Str{<:Union{ASCIICSE,UTF8CSE
 
 #Str(str::SubString{<:Str}) = unsafe_string(pointer(str.string, str.offset+1), str.ncodeunits)
 
-thisind(str::SubString{<:Str}, i::Int) = _thisind_str(str, i)
-nextind(str::SubString{<:Str}, i::Int) = _nextind_str(str, i)
 #=
 function cmp(a::SubString{String}, b::SubString{String})
     na = sizeof(a)

--- a/src/encode.jl
+++ b/src/encode.jl
@@ -34,7 +34,7 @@ function _str(str::T) where {T<:Union{Vector{UInt8}, BinaryStrings, String}}
     # handle zero length string quickly
     (siz = sizeof(str)) == 0 && return empty_ascii
     pnt = _pnt(str)
-    len, flags, num4byte, num3byte, num2byte, latin1byte = unsafe_checkstring(pnt, 1, siz)
+    len, flags, num4byte, num3byte, num2byte, latin1byte = unsafe_check_string(pnt, 1, siz)
     if flags == 0
         buf, out = _allocate(UInt8, len)
         unsafe_copyto!(out, pnt, len)
@@ -72,8 +72,8 @@ end
 
 function convert(::Type{<:Str}, str::AbstractString)
     # handle zero length string quickly
-    isempty(str) && return empty_ascii
-    len, flags = unsafe_checkstring(str)
+    is_empty(str) && return empty_ascii
+    len, flags = unsafe_check_string(str)
     _str_encode(str, len, flags)
 end
 convert(::Type{<:Str}, str::String) = _str(str)
@@ -84,7 +84,7 @@ convert(::Type{UniStr}, str::Str{<:Union{ASCIICSE,SubSet_CSEs}}) = str
 
 function convert(::Type{UniStr}, str::T) where {T<:Str}
     # handle zero length string quickly
-    isempty(str) && return empty_ascii
+    is_empty(str) && return empty_ascii
     len, flags = count_chars(T, _pnt(str), _len(str))
     _str_encode(str, len, flags)
 end
@@ -100,11 +100,11 @@ function unsafe_str(str::T;
     (siz = sizeof(str)) == 0 && return empty_ascii
     pnt = _pnt(str)
     len, flags, num4byte, num3byte, num2byte, latin1byte, invalids =
-        unsafe_checkstring(pnt, 1, siz;
-                           accept_long_null  = accept_long_null,
-                           accept_surrogates = accept_surrogates,
-                           accept_long_char  = accept_long_char,
-                           accept_invalids   = accept_invalids)
+        unsafe_check_string(pnt, 1, siz;
+                            accept_long_null  = accept_long_null,
+                            accept_surrogates = accept_surrogates,
+                            accept_long_char  = accept_long_char,
+                            accept_invalids   = accept_invalids)
     if invalids != 0
         if T == Vector{UInt8}
             buf, out = _allocate(UInt8, siz)
@@ -142,11 +142,11 @@ function unsafe_str(str::T;
     # handle zero length string quickly
     siz == 0 && return empty_ascii
     len, flags, num4byte, num3byte, num2byte, latin1, invalids =
-        unsafe_checkstring(str, 1, siz;
-                           accept_long_null  = accept_long_null,
-                           accept_surrogates = accept_surrogates,
-                           accept_long_char  = accept_long_char,
-                           accept_invalids   = accept_invalids)
+        unsafe_check_string(str, 1, siz;
+                            accept_long_null  = accept_long_null,
+                            accept_surrogates = accept_surrogates,
+                            accept_long_char  = accept_long_char,
+                            accept_invalids   = accept_invalids)
     if flags == 0
         Str(ASCIICSE, unsafe_copyto!(_allocate(siz), 1, str, 1, siz))
     elseif invalids

--- a/src/fix2.jl
+++ b/src/fix2.jl
@@ -1,0 +1,58 @@
+# This file contains code that was a part of Julia (in operators.jl)
+# License is MIT: https://julialang.org/license
+# It is used to support the new string searching syntax on v0.6.2
+
+"""
+    Fix2(f, x)
+
+A type representing a partially-applied version of function `f`, with the second
+argument fixed to the value "x".
+In other words, `Fix2(f, x)` behaves similarly to `y->f(y, x)`.
+"""
+struct Fix2{F,T} <: Function
+    f::F
+    x::T
+
+    Fix2(f::F, x::T) where {F,T} = new{F,T}(f, x)
+    Fix2(f::Type{F}, x::T) where {F,T} = new{Type{F},T}(f, x)
+end
+
+(f::Fix2)(y) = f.f(y, f.x)
+
+"""
+    isequal(x)
+
+Create a function that compares its argument to `x` using [`isequal`](@ref), i.e.
+a function equivalent to `y -> isequal(y, x)`.
+
+The returned function is of type `Base.Fix2{typeof(isequal)}`, which can be
+used to implement specialized methods.
+"""
+isequal(x) = Fix2(isequal, x)
+
+const EqualTo = Fix2{typeof(isequal)}
+
+"""
+    ==(x)
+
+Create a function that compares its argument to `x` using [`==`](@ref), i.e.
+a function equivalent to `y -> y == x`.
+
+The returned function is of type `Base.Fix2{typeof(==)}`, which can be
+used to implement specialized methods.
+"""
+==(x) = Fix2(==, x)
+
+"""
+    in(x)
+
+Create a function that checks whether its argument is [`in`](@ref) `x`, i.e.
+a function equivalent to `y -> y in x`.
+
+The returned function is of type `Base.Fix2{typeof(in)}`, which can be
+used to implement specialized methods.
+"""
+in(x) = Fix2(in, x)
+
+const OccursIn = Fix2{typeof(in)}
+

--- a/src/io.jl
+++ b/src/io.jl
@@ -1,0 +1,107 @@
+#=
+IO functions for Str and CodePoint types
+
+Copyright 2017-2018 Gandalf Software, Inc., Scott P. Jones
+Licensed under MIT License, see LICENSE.md
+=#
+@inline _write_utf8_2(io, ch) = write(io, get_utf8_2(ch)...)
+@inline _write_utf8_3(io, ch) = write(io, get_utf8_3(ch)...)
+@inline _write_utf8_4(io, ch) = write(io, get_utf8_4(ch)...)
+
+@inline _write_ucs2(io, ch) =
+    ch <= 0x7f ? write(io, ch%UInt8) : ch <= 0x7ff ? _write_utf8_2(io, ch) : _write_utf8_3(io, ch)
+
+@inline _write_utf32(io, ch) = ch <= 0xffff ? _write_ucs2(io, ch) : _write_utf8_4(io, ch)
+
+@inline print(io::IO, ch::UCS2Chr)  = _write_ucs2(io, tobase(ch))
+@inline print(io::IO, ch::UTF32Chr) = _write_utf32(io, tobase(ch))
+
+## outputting Str strings and CodePoint characters ##
+
+write(io::IO, str::Str{<:CSE,Nothing}) = write(io, str.data)
+write(io::IO, ch::CodePoint) = write(io, tobase(ch))
+
+# Todo: handle substring of Str
+
+# optimized methods to avoid iterating over chars
+print(io::IO, str::Union{T,SubString{T}}) where {T<:Str{<:Union{ASCIICSE,UTF8CSE},Nothing}} =
+    (write(io, str); nothing)
+
+## outputting Latin 1 strings ##
+
+function print(io::IO, str::LatinStrings)
+    @preserve str begin
+        pnt = _pnt(str)
+        fin = pnt + sizeof(str)
+        # Skip and write out ASCII sequences together
+        while pnt < fin
+            # Skip to first non-ASCII sequence
+            # Todo: Optimize this to look at chunks at a time to find first non-ASCII
+            beg = pnt
+            ch = 0x00
+            while (ch = get_codeunit(pnt)) < 0x80 && (pnt += 1) < fin ; end
+            # Now we have from beg to < pnt that are ASCII
+            unsafe_write(io, beg, pnt - beg)
+            pnt < fin || break
+            # Todo: Optimize sequences of more than one character > 0x7f
+            # Write out two bytes of Latin1 character encoded as UTF-8
+            _write_utf8_2(io, ch)
+            pnt += 1
+        end
+    end
+    nothing
+end
+
+_print(io, ch::UInt8) = ch <= 0x7f ? write(io, ch) : _write_utf8_2(io, ch)
+print(io::IO, ch::LatinChars) = _print(io, ch%UInt8)
+
+write(io::IO, ch::LatinChars) = write(io, ch%UInt8)
+
+## outputting UCS2 strings as UTF-8 ##
+
+function print(io::IO, str::UCS2Strings)
+    len, pnt = _lenpnt(str)
+    fin = bytoff(pnt, len)
+    while pnt < fin
+        _write_ucs2(io, get_codeunit(pnt))
+        pnt += 2
+    end
+    nothing
+end
+
+## output UTF-16 string ##
+
+function print(io::IO, str::Str{UTF16CSE})
+    pnt = _lenpnt(str)
+    siz = sizeof(str)
+    # Skip and write out ASCII sequences together
+    fin = pnt + siz
+    while pnt < fin
+        ch = get_codeunit(pnt)
+        # Handle 0x80-0x7ff
+        if ch <= 0x7f
+            write(io, ch%UInt8)
+        elseif ch <= 0x7ff
+            _write_utf8_2(io, ch)
+        elseif is_surrogate_lead(ch)
+            _write_utf8_4(io, get_supplementary(ch, get_codeunit(pnt += 2)))
+        else
+            _write_utf8_3(io, ch)
+        end
+        pnt += 2
+    end
+    nothing
+end
+
+## outputting UTF32 strings as UTF-8 ##
+
+function print(io::IO, str::UTF32Strings)
+    len, pnt = _lenpnt(str)
+    fin = bytoff(pnt, len)
+    while pnt < fin
+        _write_utf32(io, get_codeunit(pnt))
+        pnt += 4
+    end
+    nothing
+end
+

--- a/src/latin.jl
+++ b/src/latin.jl
@@ -8,10 +8,10 @@ Based in part on code for ASCIIString that used to be in Julia
 
 ## overload methods for efficiency ##
 
-isascii(str::Str{_LatinCSE}) = false
-islatin(str::LatinStrings)   = true
-isbmp(str::LatinStrings)     = true
-isunicode(str::LatinStrings) = true
+is_ascii(str::Str{_LatinCSE}) = false
+is_latin(str::LatinStrings)   = true
+is_bmp(str::LatinStrings)     = true
+is_unicode(str::LatinStrings) = true
 
 bytestring(s::LatinStrings) = s
 
@@ -55,9 +55,9 @@ end
 
 function convert(::Type{LatinStr}, str::String)
     # handle zero length string quickly
-    isempty(str) && return empty_latin
+    is_empty(str) && return empty_latin
     # get number of bytes to allocate
-    len, flags, num4byte, num3byte, num2byte, latinbyte = unsafe_checkstring(str, 1, sizeof(str))
+    len, flags, num4byte, num3byte, num2byte, latinbyte = unsafe_check_string(str, 1, sizeof(str))
     num4byte + num3byte + num2byte == 0 || unierror(UTF_ERR_INVALID_LATIN1)
     Str(LatinCSE, flags == 0 ? str : _utf8_to_latin(_pnt(str), len))
 end
@@ -68,21 +68,21 @@ convert(::Type{<:Str{_LatinCSE}}, ch::Unsigned) =
 
 function convert(::Type{_LatinStr}, str::String)
     # handle zero length string quickly
-    isempty(str) && return empty_ascii
+    is_empty(str) && return empty_ascii
     # get number of bytes to allocate
     len, flags, num4byte, num3byte, num2byte, latinbyte =
-        unsafe_checkstring(str, 1, sizeof(str))
+        unsafe_check_string(str, 1, sizeof(str))
     num4byte + num3byte + num2byte == 0 || unierror(UTF_ERR_INVALID_LATIN1)
     Str(latinbyte == 0 ? ASCIICSE : _LatinCSE,
         flags == 0 ? str : _utf8_to_latin(_pnt(str), len))
 end
 
 convert(::Type{LatinStr}, a::Vector{UInt8}) = _convert(LatinStr, a)
-convert(::Type{_LatinStr}, a::Vector{UInt8}) = _convert(isascii(a) ? ASCIIStr : _LatinStr, a)
+convert(::Type{_LatinStr}, a::Vector{UInt8}) = _convert(is_ascii(a) ? ASCIIStr : _LatinStr, a)
 
 function convert(::Type{T}, str::AbstractString) where {T<:LatinStrings}
     # Might want to have invalids_as here
-    len, flags = unsafe_checkstring(str)
+    len, flags = unsafe_check_string(str)
     (flags & ~(UTF_LONG | UTF_LATIN1)) == 0 || unierror(UTF_ERR_INVALID_LATIN1)
     buf, pnt = _allocate(UInt8, len)
     @inbounds for ch in str

--- a/src/latin.jl
+++ b/src/latin.jl
@@ -32,36 +32,6 @@ function string(collection::_UBS...)
     Str(LatinCSE, buf)
 end
 
-## outputting Latin 1 strings ##
-
-function print(io::IO, str::LatinStrings)
-    @preserve str begin
-        pnt = _pnt(str)
-        fin = pnt + sizeof(str)
-        # Skip and write out ASCII sequences together
-        while pnt < fin
-            # Skip to first non-ASCII sequence
-            # Todo: Optimize this to look at chunks at a time to find first non-ASCII
-            beg = pnt
-            ch = 0x00
-            while (ch = get_codeunit(pnt)) < 0x80 && (pnt += 1) < fin ; end
-            # Now we have from beg to < pnt that are ASCII
-            unsafe_write(io, beg, pnt - beg)
-            pnt < fin || break
-            # Todo: Optimize sequences of more than one character > 0x7f
-            # Write out two bytes of Latin1 character encoded as UTF-8
-            _write_utf8_2(io, ch)
-            pnt += 1
-        end
-    end
-    nothing
-end
-
-_print(io, ch::UInt8) = ch <= 0x7f ? write(io, ch) : _write_utf8_2(io, ch)
-print(io::IO, ch::LatinChars) = _print(io, ch%UInt8)
-
-write(io::IO, ch::LatinChars) = write(io, ch%UInt8)
-
 ## transcoding to Latin1 ##
 
 convert(::Type{T}, s::T) where {T<:LatinStrings} = s

--- a/src/latin.jl
+++ b/src/latin.jl
@@ -32,21 +32,6 @@ function string(collection::_UBS...)
     Str(LatinCSE, buf)
 end
 
-# Todo make generic version, with all CodeUnitSingle types
-function reverse(str::Str{C}) where {C<:Union{ASCIICSE, Latin_CSEs, Text1CSE, BinaryCSE}}
-    (len = _len(str)) < 2 && return str
-    @preserve str begin
-        pnt = _pnt(str)
-        buf, beg = _allocate(UInt8, len)
-        out = beg + len
-        while out >= beg
-            set_codeunit!(out -= 1, get_codeunit(pnt))
-            pnt += 1
-        end
-        Str(C, buf)
-    end
-end
-
 ## outputting Latin 1 strings ##
 
 function print(io::IO, str::LatinStrings)

--- a/src/regex.jl
+++ b/src/regex.jl
@@ -1,0 +1,165 @@
+#=
+Regex functions for Str strings
+
+Copyright 2018 Gandalf Software, Inc., Scott P. Jones, and other contributors to the Julia language
+Licensed under MIT License, see LICENSE.md
+Based in part on julia/base/regex.jl
+=#
+
+using Base.PCRE
+
+using Base: DEFAULT_COMPILER_OPTS, DEFAULT_MATCH_OPTS
+import Base: Regex, match
+
+const Regex_CSEs = Union{ASCIICSE,Latin_CSEs,Binary_CSEs}
+
+# Default is to act as if validated UTF8
+cvt_compile(::Type{<:CSE}, co) = co | PCRE.NO_UTF_CHECK | PCRE.UTF
+cvt_match(::Type{<:CSE}, co)   = co | PCRE.NO_UTF_CHECK
+
+cvt_compile(::Type{Regex_CSEs}, co) = co & ~PCRE.UTF
+cvt_match(::Type{Regex_CSEs}, co)   = co & ~PCRE.NO_UTF_CHECK
+
+cvt_compile(::Type{<:Str{C}}, co) where {C<:CSE} = cvt_compile(C, co)
+cvt_match(::Type{<:Str{C}}, co) where {C<:CSE}   = cvt_match(C, co)
+
+# String type is not validate
+cvt_compile(::Type{String}, co) = (co & ~PCRE.NO_UTF_CHECK) | PCRE.UTF
+cvt_match(::Type{String}, co)   = (co & ~PCRE.NO_UTF_CHECK)
+
+Regex(pattern::Str{C}, co, mo) where {C<:Byte_CSEs} =
+    Regex(String(pattern), cvt_compile(C, co), mo)
+Regex(pattern::Str{C}) where {C<:Byte_CSEs} =
+    Regex(String(pattern),
+          cvt_compile(C, DEFAULT_COMPILER_OPTS), cvt_match(C, DEFAULT_MATCH_OPTS))
+
+function _update_compiler_opts(flags)
+    options = DEFAULT_COMPILER_OPTS
+    for f in flags
+        options |= f=='i' ? PCRE.CASELESS  :
+                   f=='m' ? PCRE.MULTILINE :
+                   f=='s' ? PCRE.DOTALL    :
+                   f=='x' ? PCRE.EXTENDED  :
+                   throw(ArgumentError("unknown regex flag: $f"))
+    end
+    options
+end
+
+Regex(pattern::Str{C}, flags::AbstractString) where {C<:Byte_CSEs} =
+    Regex(pattern, cvt_compile(C, _update_compile_opts(flags)), cvt_match(C, DEFAULT_MATCH_OPTS))
+
+struct RegexMatchStr{T<:AbstractString}
+    match::T
+    captures::Vector{Union{Nothing,T}}
+    offset::Int
+    offsets::Vector{Int}
+    regex::Regex
+end
+
+function show(io::IO, m::RegexMatchStr)
+    print(io, "RegexMatchStr(")
+    show(io, m.match)
+    idx_to_capture_name = PCRE.capture_names(m.regex.regex)
+    if !isempty(m.captures)
+        print(io, ", ")
+        for i = 1:length(m.captures)
+            # If the capture group is named, show the name.
+            # Otherwise show its index.
+            capture_name = get(idx_to_capture_name, i, i)
+            print(io, capture_name, "=")
+            show(io, m.captures[i])
+            if i < length(m.captures)
+                print(io, ", ")
+            end
+        end
+    end
+    print(io, ")")
+end
+
+# Capture group extraction
+getindex(m::RegexMatchStr, idx::Integer) = m.captures[idx]
+function getindex(m::RegexMatchStr, name::Symbol)
+    idx = PCRE.substring_number_from_name(m.regex.regex, name)
+    idx <= 0 && error("no capture group named $name found in regex")
+    m[idx]
+end
+
+getindex(m::RegexMatchStr, name::AbstractString) = m[Symbol(name)]
+
+"""
+Check if the compile flags match the current search
+
+If not, free up old compilation, and recompile
+For better performance, the Regex object should hold spots for 5 compiled regexes,
+for 8-bit, UTF-8, 16-bit, UTF-16, and 32-bit code units
+"""
+function check_compile(::Type{C}, regex::Regex) where {C<:Union{CSE,String}}
+    re = regex.regex
+    # ASCII is compatible with all (current) types, don't recompile
+    C == ASCIICSE && re != C_NULL && return
+    oldopt = regex.compile_options
+    cvtcomp = cvt_compile(C, oldopt)
+    if cvtcomp != oldopt
+        regex.compile_options = cvtcomp
+        re == C_NULL || (PCRE.free_re(re); regex.regex = re = C_NULL)
+        regex.match_data == C_NULL ||
+            (PCRE.free_match_data(regex.match_data); regex.match_data = C_NULL)
+    end
+    if re == C_NULL
+        regex.regex = re = PCRE.compile(regex.pattern, cvtcomp)
+        PCRE.jit_compile(re)
+        regex.match_data = PCRE.create_match_data(re)
+        regex.ovec = PCRE.get_ovec(regex.match_data)
+    end
+    nothing
+end
+
+function _match(::Type{C}, re, str, idx, add_opts) where {C<:CSE}
+    check_compile(C, re)
+    PCRE.exec(re.regex, str, idx-1, cvt_match(C, re.match_options | add_opts), re.match_data) ||
+        return nothing
+    ovec = re.ovec
+    n = div(length(ovec),2) - 1
+    mat = SubString(str, ovec[1]+1, prevind(str, ovec[2]+1))
+    cap = Union{Nothing,SubString{typeof(str)}}[ovec[2i+1] == PCRE.UNSET ?
+                                               nothing :
+                                               SubString(str, ovec[2i+1]+1,
+                                                         prevind(str, ovec[2i+2]+1)) for i=1:n]
+    off = Int[ ovec[2i+1]+1 for i=1:n ]
+    RegexMatchStr(mat, cap, Int(ovec[1]+1), off, re)
+end
+
+match(re::Regex, str::Str{C}, idx::Integer, add_opts::UInt32=UInt32(0)) where {C<:CSE} =
+    error("Regex not supported yet on strings with codeunit == UInt16 or UInt32")
+match(re::Regex, str::Str{C}, idx::Integer, add_opts::UInt32=UInt32(0)) where {C<:Regex_CSEs} =
+    _match(C, re, str, Int(idx), add_opts)
+match(re::Regex, str::Str{UTF8CSE}, idx::Integer, add_opts::UInt32=UInt32(0)) =
+    _match(UTF8CSE, re, str, Int(idx), add_opts)
+match(re::Regex, str::Str{_LatinCSE}, idx::Integer, add_opts::UInt32=UInt32(0)) =
+    _match(LatinCSE, re, Str{LatinCSE}(str), Int(idx), add_opts)
+
+
+const StrOrSubStr{T} = Union{T,SubString{<:T}}
+
+function _fnd(::Type{C}, re, str, idx) where {C}
+    if idx > ncodeunits(str)
+        @boundscheck boundserr(str, idx)
+        return _not_found
+    end
+    check_compile(C, re)
+    (PCRE.exec(re.regex, str, idx-1, cvt_match(C, re.match_options), re.match_data)
+     ? ((Int(re.ovec[1])+1):prevind(str,Int(re.ovec[2])+1)) : _not_found)
+end
+
+fnd(::Type{Fwd}, re::Regex, str::StrOrSubStr{AbstractString}, idx::Integer) =
+    throw(ArgumentError("regex search is only available for the String or Str types with " *
+                        "codeunit == UInt8, or substrings of those types, use UTF8Str to convert"))
+
+fnd(::Type{Fwd}, re::Regex, str::StrOrSubStr{Str{C}}, idx::Integer) where {C<:Regex_CSEs} =
+    _fnd(C, re, str, idx)
+fnd(::Type{Fwd}, re::Regex, str::StrOrSubStr{Str{C}}, idx::Integer) where {C<:UTF8CSE} =
+    _fnd(C, re, str, idx)
+fnd(::Type{Fwd}, re::Regex, str::StrOrSubStr{Str{C}}, idx::Integer) where {C<:_LatinCSE} =
+    _fnd(LatinCSE, re, str, idx)
+fnd(::Type{Fwd}, re::Regex, str::StrOrSubStr{String}, idx::Integer) =
+    _fnd(String, re, str, idx)

--- a/src/regex.jl
+++ b/src/regex.jl
@@ -60,7 +60,7 @@ function show(io::IO, m::RegexMatchStr)
     print(io, "RegexMatchStr(")
     show(io, m.match)
     idx_to_capture_name = PCRE.capture_names(m.regex.regex)
-    if !isempty(m.captures)
+    if !is_empty(m.captures)
         print(io, ", ")
         for i = 1:length(m.captures)
             # If the capture group is named, show the name.

--- a/src/search.jl
+++ b/src/search.jl
@@ -1,5 +1,10 @@
-# This file includes code originally from Julia.
-# License is MIT: https://julialang.org/license
+#=
+Search functions for Str strings
+
+Copyright 2018 Gandalf Software, Inc., Scott P. Jones, and other contributors to the Julia language
+Licensed under MIT License, see LICENSE.md
+Based in part on julia/base/strings/search.jl
+=#
 
 export found, find_result, fnd
 export Dir, Fwd, Rev
@@ -80,49 +85,7 @@ find_result(::Type{<:AbstractString}, v) = v
 
 @static if VERSION < v"0.7.0-DEV"
 
-export EqualTo, equalto, OccursIn, occursin
-
-struct EqualTo{T} <: Function
-    x::T
-
-    EqualTo(x::T) where {T} = new{T}(x)
-end
-
-(f::EqualTo)(y) = isequal(f.x, y)
-
-"""
-    equalto(x)
-
-Create a function that compares its argument to `x` using [`isequal`](@ref); i.e. returns
-`y->isequal(x,y)`.
-
-The returned function is of type `Base.EqualTo`. This allows dispatching to
-specialized methods by using e.g. `f::Base.EqualTo` in a method signature.
-"""
-const equalto = EqualTo
-
-struct OccursIn{T} <: Function
-    x::T
-
-    OccursIn(x::T) where {T} = new{T}(x)
-end
-
-(f::OccursIn)(y) = y in f.x
-
-"""
-    occursin(x)
-
-Create a function that checks whether its argument is [`in`](@ref) `x`; i.e. returns
-`y -> y in x`.
-
-The returned function is of type `Base.OccursIn`. This allows dispatching to
-specialized methods by using e.g. `f::Base.OccursIn` in a method signature.
-"""
-const occursin = OccursIn
-
 else
-
-import Base: EqualTo, equalto, OccursIn, occursin
 
 nothing_sentinel(i) = i == 0 ? nothing : i
 Base.findnext(a, b::Str, i) = nothing_sentinel(fnd(Fwd, a, b, i))
@@ -230,7 +193,8 @@ function _srch_cp(::Rev, cus, str, cp, pos, len)
     0
 end
 
-fnd(::Type{D}, pred::EqualTo{<:AbsChar}, str::AbstractString, pos::Integer) where {D<:Dir} =
+fnd(::Type{D}, pred::P, str::AbstractString,
+    pos::Integer) where {P<:Base.Fix2{Union{typeof(==),typeof(isequal)}, <:AbsChar}, D<:Dir} =
     fnd(D, pred.x, str, pos)
 
 function fnd(::Type{D}, ch::AbsChar, str::AbstractString, pos::Integer) where {D<:Dir}
@@ -392,141 +356,3 @@ in(chr::AbsChar,   str::Str)            = contains(str, chr)
 in(pat::Str, str::Str)                  = contains(str, pat)
 in(pat::Str, str::AbstractString)       = contains(str, pat)
 in(pat::AbstractString, str::Str)       = contains(str, pat)
-
-using Base.PCRE
-
-using Base: DEFAULT_COMPILER_OPTS, DEFAULT_MATCH_OPTS
-import Base: Regex, match
-
-const Regex_CSEs = Union{ASCIICSE,Latin_CSEs,Binary_CSEs}
-
-cvt_compile(::Type{<:CSE}, co)  = cvt_compile(UTF8CSE, co)
-cvt_match(::Type{<:CSE}, co)    = cvt_match(UTF8CSE, co)
-cvt_compile(::Type{Regex_CSEs}, co) = co & ~PCRE.UTF
-cvt_match(::Type{Regex_CSEs}, co)   = co & ~PCRE.NO_UTF_CHECK
-cvt_compile(::Type{UTF8CSE}, co)  = co | PCRE.NO_UTF_CHECK | PCRE.UTF
-cvt_match(::Type{UTF8CSE}, co)    = co | PCRE.NO_UTF_CHECK
-
-Regex(pattern::Str{C}, co, mo) where {C<:Byte_CSEs} =
-    Regex(String(pattern), cvt_compile(C, co), mo)
-Regex(pattern::Str{C}) where {C<:Byte_CSEs} =
-    Regex(String(pattern),
-          cvt_compile(C, DEFAULT_COMPILER_OPTS), cvt_match(C, DEFAULT_MATCH_OPTS))
-
-function _update_compiler_opts(flags)
-    options = DEFAULT_COMPILER_OPTS
-    for f in flags
-        options |= f=='i' ? PCRE.CASELESS  :
-                   f=='m' ? PCRE.MULTILINE :
-                   f=='s' ? PCRE.DOTALL    :
-                   f=='x' ? PCRE.EXTENDED  :
-                   throw(ArgumentError("unknown regex flag: $f"))
-    end
-    options
-end
-
-Regex(pattern::Str{C}, flags::AbstractString) where {C<:Byte_CSEs} =
-    Regex(pattern, cvt_compile(C, _update_compile_opts(flags)), cvt_match(C, DEFAULT_MATCH_OPTS))
-
-struct RegexMatchStr{T<:AbstractString}
-    match::T
-    captures::Vector{Union{Nothing,T}}
-    offset::Int
-    offsets::Vector{Int}
-    regex::Regex
-end
-
-function show(io::IO, m::RegexMatchStr)
-    print(io, "RegexMatchStr(")
-    show(io, m.match)
-    idx_to_capture_name = PCRE.capture_names(m.regex.regex)
-    if !isempty(m.captures)
-        print(io, ", ")
-        for i = 1:length(m.captures)
-            # If the capture group is named, show the name.
-            # Otherwise show its index.
-            capture_name = get(idx_to_capture_name, i, i)
-            print(io, capture_name, "=")
-            show(io, m.captures[i])
-            if i < length(m.captures)
-                print(io, ", ")
-            end
-        end
-    end
-    print(io, ")")
-end
-
-# Capture group extraction
-getindex(m::RegexMatchStr, idx::Integer) = m.captures[idx]
-function getindex(m::RegexMatchStr, name::Symbol)
-    idx = PCRE.substring_number_from_name(m.regex.regex, name)
-    idx <= 0 && error("no capture group named $name found in regex")
-    m[idx]
-end
-
-getindex(m::RegexMatchStr, name::AbstractString) = m[Symbol(name)]
-
-"""
-Check if the compile flags match the current search
-
-If not, free up old compilation, and recompile
-For better performance, the Regex object should hold spots for 5 compiled regexes,
-for 8-bit, UTF-8, 16-bit, UTF-16, and 32-bit code units
-"""
-function check_compile(::Type{C}, regex::Regex) where {C<:CSE}
-    # ASCII is compatible with all (current) types, don't recompile
-    re = regex.regex
-    C == ASCIICSE && re != C_NULL && return
-    oldopt = regex.compile_options
-    cvtcomp = cvt_compile(C, oldopt)
-    if cvtcomp != oldopt
-        regex.compile_options = cvtcomp
-        re == C_NULL || (PCRE.free_re(re); regex.regex = re = C_NULL)
-        regex.match_data == C_NULL ||
-            (PCRE.free_match_data(regex.match_data); regex.match_data = C_NULL)
-    end
-    if re == C_NULL
-        regex.regex = re = PCRE.compile(regex.pattern, cvtcomp)
-        PCRE.jit_compile(re)
-        regex.match_data = PCRE.create_match_data(re)
-        regex.ovec = PCRE.get_ovec(regex.match_data)
-    end
-    nothing
-end
-
-function _match(::Type{C}, re, str, idx, add_opts) where {C<:CSE}
-    check_compile(C, re)
-    PCRE.exec(re.regex, str, idx-1, cvt_match(C, re.match_options | add_opts), re.match_data) ||
-        return nothing
-    ovec = re.ovec
-    n = div(length(ovec),2) - 1
-    mat = SubString(str, ovec[1]+1, prevind(str, ovec[2]+1))
-    cap = Union{Nothing,SubString{typeof(str)}}[ovec[2i+1] == PCRE.UNSET ?
-                                               nothing :
-                                               SubString(str, ovec[2i+1]+1,
-                                                         prevind(str, ovec[2i+2]+1)) for i=1:n]
-    off = Int[ ovec[2i+1]+1 for i=1:n ]
-    RegexMatchStr(mat, cap, Int(ovec[1]+1), off, re)
-end
-
-match(re::Regex, str::Str{C}, idx::Integer, add_opts::UInt32=UInt32(0)) where {C<:CSE} =
-    error("Regex not supported yet on strings with codeunit == UInt16 or UInt32")
-match(re::Regex, str::Str{C}, idx::Integer, add_opts::UInt32=UInt32(0)) where {C<:Regex_CSEs} =
-    _match(C, re, str, Int(idx), add_opts)
-match(re::Regex, str::Str{UTF8CSE}, idx::Integer, add_opts::UInt32=UInt32(0)) =
-    _match(UTF8CSE, re, str, Int(idx), add_opts)
-match(re::Regex, str::Str{_LatinCSE}, idx::Integer, add_opts::UInt32=UInt32(0)) =
-    _match(LatinCSE, re, Str{LatinCSE}(str), Int(idx), add_opts)
-
-
-function fnd(::Type{Fwd}, re::Regex,
-             str::Union{AbstractString,SubString{AbstractString}}, idx::Integer)
-    if idx > ncodeunits(str)
-        @boundscheck boundserr(str, idx)
-        return _not_found
-    end
-    C = cse(str)
-    check_compile(C, re)
-    (PCRE.exec(re.regex, str, idx-1, cvt_match(C, re.match_options), re.match_data)
-     ? ((Int(re.ovec[1])+1):prevind(str,Int(re.ovec[2])+1)) : _not_found)
-end

--- a/src/types.jl
+++ b/src/types.jl
@@ -205,7 +205,7 @@ for nam in vcat(_binname, _cpname2, _cpname4, _subsetnam, _mbwname)
         @eval empty_str(::Type{$cse}) = $emp
         @eval export $sym
     end
-    @eval convert(::Type{T}, str::T) where {T<:$sym} = str
+    @eval convert(::Type{$sym}, str::$sym) = str
 end
 empty_str(::Type{<:Str{C}}) where {C<:CSE} = empty_str(C)
 empty_str(::Type{String}) = empty_string

--- a/src/unicode.jl
+++ b/src/unicode.jl
@@ -1,259 +1,64 @@
-# This file includes code from Julia.
-# License is MIT: http://julialang.org/license
+#=
+Character and string classification functions
 
-# The plan is to rewrite all of the functionality to not use the utf8proc library,
-# and to use tables loaded up on initialization, as with StringLiterals.jl
+Copyright 2017-2018 Gandalf Software, Inc., Scott P. Jones,
+Licensed under MIT License, see LICENSE.md
+=#
 
-# Currently, for characters outside the Latin1 subset, this depends on the following C calls:
-# utf8proc_decompose
-# utf8proc_reencode
-# utf8proc_charwidth
-# utf8proc_category
-# utf8proc_category_string
-# utf8proc_tolower
-# utf8proc_toupper
-# utf8proc_totitle
-
-# For grapheme segmentation, this currently depends on the following 2 C calls:
-# utf8proc_grapheme_break
-# utf8proc_grapheme_break_stateful
-
-# Unicode category constants
-module Uni
-const CN = 0
-const LU = 1
-const LL = 2
-const LT = 3
-const LM = 4
-const LO = 5
-const MN = 6
-const MC = 7
-const ME = 8
-const ND = 9
-const NL = 10
-const NO = 11
-const PC = 12
-const PD = 13
-const PS = 14
-const PE = 15
-const PI = 16
-const PF = 17
-const PO = 18
-const SM = 19
-const SC = 20
-const SK = 21
-const SO = 22
-const ZS = 23
-const ZL = 24
-const ZP = 25
-const CC = 26
-const CF = 27
-const CS = 28
-const CO = 29
-
-# strings corresponding to the category constants
-const catstrings = [
-    "Other, not assigned",
-    "Letter, uppercase",
-    "Letter, lowercase",
-    "Letter, titlecase",
-    "Letter, modifier",
-    "Letter, other",
-    "Mark, nonspacing",
-    "Mark, spacing combining",
-    "Mark, enclosing",
-    "Number, decimal digit",
-    "Number, letter",
-    "Number, other",
-    "Punctuation, connector",
-    "Punctuation, dash",
-    "Punctuation, open",
-    "Punctuation, close",
-    "Punctuation, initial quote",
-    "Punctuation, final quote",
-    "Punctuation, other",
-    "Symbol, math",
-    "Symbol, currency",
-    "Symbol, modifier",
-    "Symbol, other",
-    "Separator, space",
-    "Separator, line",
-    "Separator, paragraph",
-    "Other, control",
-    "Other, format",
-    "Other, surrogate",
-    "Other, private use",
-    "Invalid, too high",
-    "Malformed, bad data",
-]
-
-const STABLE    = 1<<1
-const COMPAT    = 1<<2
-const COMPOSE   = 1<<3
-const DECOMPOSE = 1<<4
-const IGNORE    = 1<<5
-const REJECTNA  = 1<<6
-const NLF2LS    = 1<<7
-const NLF2PS    = 1<<8
-const NLF2LF    = NLF2LS | NLF2PS
-const STRIPCC   = 1<<9
-const CASEFOLD  = 1<<10
-const CHARBOUND = 1<<11
-const LUMP      = 1<<12
-const STRIPMARK = 1<<13
-end
-
-############################################################################
-
-utf8proc_error(result) =
-    error(unsafe_string(ccall(:utf8proc_errmsg, Cstring, (Cssize_t,), result)))
-
-function utf8proc_map(::Type{T}, str, options::Integer) where {T<:Str}
-    nwords = ccall(:utf8proc_decompose, Int, (Ptr{UInt8}, Int, Ptr{UInt8}, Int, Cint),
-                   str, sizeof(str), C_NULL, 0, options)
-    nwords < 0 && utf8proc_error(nwords)
-    buffer = _allocate(nwords*4)
-    nwords = ccall(:utf8proc_decompose, Int, (Ptr{UInt8}, Int, Ptr{UInt8}, Int, Cint),
-                   str, sizeof(str), buffer, nwords, options)
-    nwords < 0 && utf8proc_error(nwords)
-    nbytes = ccall(:utf8proc_reencode, Int, (Ptr{UInt8}, Int, Cint), buffer, nwords, options)
-    nbytes < 0 && utf8proc_error(nbytes)
-    T(resize!(buffer, nbytes))
-end
-
-utf8proc_map(str::T, options::Integer) where {T<:Str} = utf8proc_map(T, UTF8Str(str), options)
-utf8proc_map(str::Str{UTF8CSE}, options::Integer) = utf8proc_map(UTF8Str, str, options)
-
-############################################################################
-
-import Base: isalpha, isdigit, isxdigit, iscntrl, ispunct, isspace, isprint,
-             islower, isupper, lowercase, uppercase, titlecase, lcfirst, ucfirst, isascii
-
-@condimport isnumeric
-@condimport textwidth
-@condimport isalnum
-@condimport isgraph
-
-@static if isdefined(Base, :Unicode) && isdefined(Base.Unicode, :graphemes)
-    import Base.Unicode: graphemes
-else
-    import Base: graphemes
-end
-
-@static isdefined(Base, :textwidth) || (textwidth(str::String) = strwidth(str))
-
-export is_alnum, is_graph
+@static isdefined(Base, :textwidth) || (text_width(str::AbstractString) = strwidth(str))
+@static isdefined(Base, :textwidth) || (text_width(ch::Char) = charwidth(ch))
 
 # Recommended by deprecate
 @static if VERSION < v"0.7.0-DEV"
-    is_alnum(ch::Char) = isalnum(ch)
-    is_graph(ch::Char) = isgraph(ch)
+    import Base: is_assigned_char, normalize_string
+    Base.is_assigned_char(ch::CodePoint) = is_assigned(ch)
+    Base.normalize_string(str::Str, opt) = normalize(str, opt)
+    Base.strwidth(str::Str) = text_width(str)
+    Base.charwidth(ch::CodePoint) = text_width(ch)
 else
-    is_alnum(ch::Char) = isalpha(ch) || isnumeric(ch)
-    is_graph(ch::Char) = isprint(ch) && !(isspace(ch))
+    Base.Unicode.normalize(str::Str, opt) = normalize(str, opt)
+    Base.Unicode.isassigned(ch::CodePoint) = is_assigned(ch)
+    export is_assigned
+    is_graphic(ch::Char) = is_graphic(tobase(ch))
+    is_alphanumeric(ch::Char) = is_alphanumeric(tobase(ch))
 end
-is_alnum(ch::CodePoint) = isalnum(ch)
-is_graph(ch::CodePoint) = isgraph(ch)
-
-export isgraphemebreak
 
 @static if isdefined(Base, :isnumber)
     import Base: isnumber
-    isnumber(val::CodePoint) = isnumeric(val)
+    isnumber(val::CodePoint) = is_numeric(val)
 end
-@static if VERSION < v"0.7.0-DEV"
-    import Base: is_assigned_char, isassigned, normalize_string
-    is_assigned_char(ch::CodePoint) = isassigned(ch)
-    normalize_string(::Type{T}, str::T; kwargs...) where {T<:Str} = normalize(T, str; kwargs...)
-else
-    import Base.Unicode: isassigned, normalize
-end
-
-############################################################################
-
-function normalize(::Type{T}, str::T;
-                   stable::Bool      = false,
-                   compat::Bool      = false,
-                   compose::Bool     = true,
-                   decompose::Bool   = false,
-                   stripignore::Bool = false,
-                   rejectna::Bool    = false,
-                   newline2ls::Bool  = false,
-                   newline2ps::Bool  = false,
-                   newline2lf::Bool  = false,
-                   stripcc::Bool     = false,
-                   casefold::Bool    = false,
-                   lump::Bool        = false,
-                   stripmark::Bool   = false,
-                   ) where {T<:Str}
-    (compose & decompose) && unierror(UTF_ERR_DECOMPOSE_COMPOSE)
-    (!(compat | stripmark) & (compat | stripmark)) && unierror(UTF_ERR_COMPAT_STRIPMARK)
-    newline2ls + newline2ps + newline2lf > 1 && unierror(UTF_ERR_NL_CONVERSION)
-    flags =
-        ifelse(stable,      Uni.STABLE, 0) |
-        ifelse(compat,      Uni.COMPAT, 0) |
-        ifelse(decompose,   Uni.DECOMPOSE, 0) |
-        ifelse(compose,     Uni.COMPOSE, 0) |
-        ifelse(stripignore, Uni.IGNORE, 0) |
-        ifelse(rejectna,    Uni.REJECTNA, 0) |
-        ifelse(newline2ls,  Uni.NLF2LS, 0) |
-        ifelse(newline2ps,  Uni.NLF2PS, 0) |
-        ifelse(newline2lf,  Uni.NLF2LF, 0) |
-        ifelse(stripcc,     Uni.STRIPCC, 0) |
-        ifelse(casefold,    Uni.CASEFOLD, 0) |
-        ifelse(lump,        Uni.LUMP, 0) |
-        ifelse(stripmark,   Uni.STRIPMARK, 0)
-    T(utf8proc_map(str, flags))
-end
-
-normalize(str::T, options::Integer) where {T<:Str} = normalize(T, UTF8Str(str), options)
-normalize(str::Str{UTF8CSE}, options::Integer) = normalize(UTF8Str, str, options)
-
-normalize(str::Str, nf::Symbol) =
-    utf8proc_map(str, nf == :NFC ? (Uni.STABLE | Uni.COMPOSE) :
-                 nf == :NFD ? (Uni.STABLE | Uni.DECOMPOSE) :
-                 nf == :NFKC ? (Uni.STABLE | Uni.COMPOSE | Uni.COMPAT) :
-                 nf == :NFKD ? (Uni.STABLE | Uni.DECOMPOSE | Uni.COMPAT) :
-                 unierror(UTF_ERR_NORMALIZE, nf))
 
 ############################################################################
 
 ## character column width function ##
 
-textwidth(ch::CodeUnitTypes) = Int(ccall(:utf8proc_charwidth, Cint, (UInt32,), ch))
-textwidth(ch::ASCIIChr) = 1
-textwidth(ch::LatinChars) = 1
-textwidth(ch::CodePoint) = textwidth(tobase(ch))
+text_width(ch::CodeUnitTypes) = utf8proc_charwidth(ch)
+text_width(ch::ASCIIChr) = 1
+text_width(ch::LatinChars) = 1
+text_width(ch::CodePoint) = text_width(tobase(ch))
 
-textwidth(str::Str) = mapreduce(textwidth, +, 0, str)
-textwidth(str::ASCIIStr) = length(str)
-textwidth(str::LatinStrings) = length(str)
+text_width(str::Str) = mapreduce(text_width, +, 0, str)
+text_width(str::Str{Union{ASCIICSE,Latin_CSEs}}) = length(str)
 
 ############################################################################
 
-@inline __cat(ch) = ccall(:utf8proc_category, Cint, (UInt32,), ch)
-@inline _cat(ch::CodePoint) = __cat(tobase(ch))
-@inline _cat(ch::CodeUnitTypes) = ch <= 0x10ffff ? __cat(ch) : Cint(30)
-@inline _cat(ch::Text4Chr)  = _cat(ch%UInt32)
+@inline _cat(ch::CodePoint)     = utf8proc_cat(tobase(ch))
+@inline _cat(ch::CodeUnitTypes) = ch <= 0x10ffff ? utf8proc_cat(ch) : Cint(30)
+@inline _cat(ch::Text4Chr)      = _cat(ch%UInt32)
 
 # returns code in 0:30 giving Unicode category
 @inline category_code(ch::CodePointTypes) = _cat(ch)
 
-@inline _cat_abbr(ch::CodePointTypes) =
-    unsafe_string(ccall(:utf8proc_category_string, Cstring, (UInt32,), tobase(ch)))
-
-@inline _lowercase_u(ch) = ccall(:utf8proc_tolower, UInt32, (UInt32,), ch)
-@inline _uppercase_u(ch) = ccall(:utf8proc_toupper, UInt32, (UInt32,), ch)
-@inline _titlecase_u(ch) = ccall(:utf8proc_totitle, UInt32, (UInt32,), ch)
+@inline _cat_abbr(ch::CodePointTypes) = utf8proc_cat_abbr(tobase(ch))
 
 # more human-readable representations of the category code
-@inline category_abbrev(ch::CodePoint) = _cat_abbr(ch)
-@inline category_abbrev(ch::CodeUnitTypes)   = ch <= 0x10ffff ? _cat_abbr(ch) : "In"
-@inline category_abbrev(ch::Text4Chr) = category_abbrev(ch%UInt32)
+@inline category_abbrev(ch::CodePoint)     = _cat_abbr(ch)
+@inline category_abbrev(ch::CodeUnitTypes) = ch <= 0x10ffff ? _cat_abbr(ch) : "In"
+@inline category_abbrev(ch::Text4Chr)      = category_abbrev(ch%UInt32)
 
 category_string(ch::CodePointTypes) = category_strings[category_code(ch) + 1]
 
-isassigned(ch::CodePointTypes) = category_code(ch) != Uni.CN
+is_assigned(ch::CodePointTypes) = category_code(ch) != Uni.CN
 
 _cat_mask(a) = a
 @inline _cat_mask(a, b) = (1%UInt << a%UInt) | (1%UInt << b%UInt)
@@ -322,57 +127,58 @@ const _isnumeric_a = _isdigit
 ############################################################################
 # Fallback definitions for all CodePoint types
 
-@inline iscntrl(ch::CodePointTypes)  = _iscntrl(tobase(ch))
-@inline isdigit(ch::CodePointTypes)  = _isdigit(tobase(ch))
-@inline isxdigit(ch::CodePointTypes) = _isxdigit(tobase(ch))
+@inline is_control(ch::CodePointTypes)   = _iscntrl(tobase(ch))
+@inline is_digit(ch::CodePointTypes)     = _isdigit(tobase(ch))
+@inline is_hex_digit(ch::CodePointTypes) = _isxdigit(tobase(ch))
 
-@inline isascii(ch::Unsigned)    = ch <= 0x7f
-@inline isascii(ch::CodePoint)   = isascii(tobase(ch))
-@inline isascii(ch::ASCIIChr)    = true
+@inline is_ascii(ch::Unsigned)    = ch <= 0x7f
+@inline is_ascii(ch::CodePoint)   = is_ascii(tobase(ch))
+@inline is_ascii(ch::ASCIIChr)    = true
 
-@inline islatin(ch::Unsigned)    = ch <= 0xff
-@inline islatin(ch::CodePoint)   = islatin(tobase(ch))
+@inline is_latin(ch::Unsigned)    = ch <= 0xff
+@inline is_latin(ch::CodePoint)   = is_latin(tobase(ch))
 
-@inline isbmp(ch::Unsigned)      = ch <= 0xffff && !is_surrogate_codeunit(ch)
-@inline isbmp(ch::UInt8)         = true
-@inline isbmp(ch::CodePoint)     = isbmp(tobase(ch))
+@inline is_bmp(ch::Unsigned)      = ch <= 0xffff && !is_surrogate_codeunit(ch)
+@inline is_bmp(ch::UInt8)         = true
+@inline is_bmp(ch::CodePoint)     = is_bmp(tobase(ch))
 
-@inline isunicode(ch::Unsigned)  = ch <= 0x10ffff && !is_surrogate_codeunit(ch)
-@inline isunicode(ch::UInt8)     = true
-@inline isunicode(ch::CodePoint) = isunicode(tobase(ch))
+@inline is_unicode(ch::Unsigned)  = ch <= 0x10ffff && !is_surrogate_codeunit(ch)
+@inline is_unicode(ch::UInt8)     = true
+@inline is_unicode(ch::CodePoint) = is_unicode(tobase(ch))
 
-const _catfuns = (:numeric, :punct, :space, :lower, :upper, :alpha, :alnum, :print, :graph)
+const _catfuns =
+    ((:numeric,      :numeric),
+     (:punctuation,  :punct),
+     (:space,        :space),
+     (:lowercase,    :lower),
+     (:uppercase,    :upper),
+     (:alpha,        :alpha),
+     (:alphanumeric, :alnum),
+     (:printable,    :print),
+     (:graphic,      :graph))
 
-for fnam in _catfuns
-    isfnam  = Symbol(string("is", fnam))
+for (nnam, fnam) in _catfuns
+    isnam  = Symbol(string("is_", nnam))
     namroot  = string("_is", fnam)
     fnam_a  = Symbol(string(namroot, "_a"))
     fnam_al = Symbol(string(namroot, "_al"))
     fnam_ch = Symbol(string(namroot, "_ch"))
         
-    @eval $(fnam_al)(ch) = isascii(ch) ? $(fnam_a)(ch) : $(Symbol(string(namroot, "_l")))(ch)
-    @eval $(fnam_ch)(ch) = islatin(ch) ? $(fnam_al)(ch) : $(Symbol(string(namroot, "_u")))(ch)
-    @eval $(isfnam)(ch::CodePointTypes) = $(fnam_ch)(tobase(ch))
-    @eval $(isfnam)(ch::ASCIIChr)      = $(fnam_a)(tobase(ch))
-    @eval $(isfnam)(ch::LatinChars)    = $(fnam_al)(tobase(ch))
+    @eval $(fnam_al)(ch) = is_ascii(ch) ? $(fnam_a)(ch) : $(Symbol(string(namroot, "_l")))(ch)
+    @eval $(fnam_ch)(ch) = is_latin(ch) ? $(fnam_al)(ch) : $(Symbol(string(namroot, "_u")))(ch)
+    @eval $(isnam)(ch::CodePointTypes) = $(fnam_ch)(tobase(ch))
+    @eval $(isnam)(ch::ASCIIChr)       = $(fnam_a)(tobase(ch))
+    @eval $(isnam)(ch::LatinChars)     = $(fnam_al)(tobase(ch))
 end
 
 ############################################################################
-# iterators for grapheme segmentation
-
-isgraphemebreak(c1::CodePointTypes, c2::CodePointTypes) =
-    !(c1 <= 0x10ffff && c2 <= 0x10ffff) ||
-    ccall(:utf8proc_grapheme_break, Bool, (UInt32, UInt32), c1, c2)
-
-# Stateful grapheme break required by Unicode-9 rules: the string
-# must be processed in sequence, with state initialized to Ref{Int32}(0).
-# Requires utf8proc v2.0 or later.
-isgraphemebreak!(state::Ref{Int32}, c1::CodePointTypes, c2::CodePointTypes) =
-    ((c1 <= 0x10ffff && c2 <= 0x10ffff)
-     ? ccall(:utf8proc_grapheme_break_stateful, Bool, (UInt32, UInt32, Ref{Int32}), c1, c2, state)
-     : (state[] = 0; true))
 
 @static if isdefined(Base, :ismalformed)
     Base.ismalformed(ch::CodePoint) = false
     Base.isoverlong(ch::CodePoint) = false
+    is_malformed(ch) = ismalformed(ch)
+    is_overlong(ch) = isoverlong(ch)
+else
+    is_malformed(ch) = false
+    is_overlong(ch) = false
 end

--- a/src/utf16.jl
+++ b/src/utf16.jl
@@ -171,17 +171,6 @@ function print(io::IO, str::UCS2Strings)
     nothing
 end
 
-function print(io::IO, str::UTF32Strings)
-    len, pnt = _lenpnt(str)
-    cnt = 0
-    fin = bytoff(pnt, len)
-    while pnt < fin
-        _write_utf32(io, get_codeunit(pnt))
-        pnt += 4
-    end
-    nothing
-end
-
 ## output UTF-16 string ##
 
 function print(io::IO, str::Str{UTF16CSE})

--- a/src/utf16.jl
+++ b/src/utf16.jl
@@ -127,9 +127,7 @@ function reverseind(str::Str{<:UTF16CSE}, i::Integer)
     is_surrogate_trail(get_codeunit(pnt, j)) ? j - 1 : j
 end
 
-function reverse(str::Str{<:UTF16CSE})
-    (len = _len(str)) < 2 && return str
-    pnt = _pnt(str)
+function _reverse(::CodeUnitMulti, ::Type{UTF16CSE}, len, pnt::Ptr{T}) where {T<:CodeUnitTypes}
     buf, beg = _allocate(UInt16, len)
     out = bytoff(beg, len)
     while out > beg
@@ -139,19 +137,6 @@ function reverse(str::Str{<:UTF16CSE})
         pnt += 2
     end
     Str(UTF16CSE, buf)
-end
-
-function reverse(str::Str{C}) where {C<:Union{Text2CSE,Text4CSE,UCS2_CSEs,UTF32_CSEs}}
-    (len = _len(str)) < 2 && return str
-    pnt = _pnt(str)
-    T = codeunit(str)
-    buf, beg = _allocate(T, len)
-    out = bytoff(beg, len)
-    while out > beg
-        set_codeunit!(out -= sizeof(T), get_codeunit(pnt))
-        pnt += sizeof(T)
-    end
-    Str(C, buf)
 end
 
 @inline _isvalid_char_pos(::CodeUnitMulti, str::Str{<:UTF16CSE}, pos::Integer) =

--- a/src/utf16.jl
+++ b/src/utf16.jl
@@ -159,42 +159,6 @@ end
 
 # These need to change to output directly, not converted to UTF-8
 
-## outputting UCS2 strings ##
-
-function print(io::IO, str::UCS2Strings)
-    len, pnt = _lenpnt(str)
-    fin = bytoff(pnt, len)
-    while pnt < fin
-        _write_ucs2(io, get_codeunit(pnt))
-        pnt += 2
-    end
-    nothing
-end
-
-## output UTF-16 string ##
-
-function print(io::IO, str::Str{UTF16CSE})
-    pnt = _lenpnt(str)
-    siz = sizeof(str)
-    # Skip and write out ASCII sequences together
-    fin = pnt + siz
-    while pnt < fin
-        ch = get_codeunit(pnt)
-        # Handle 0x80-0x7ff
-        if ch <= 0x7f
-            write(io, ch%UInt8)
-        elseif ch <= 0x7ff
-            _write_utf8_2(io, ch)
-        elseif is_surrogate_lead(ch)
-            _write_utf8_4(io, get_supplementary(ch, get_codeunit(pnt += 2)))
-        else
-            _write_utf8_3(io, ch)
-        end
-        pnt += 2
-    end
-    nothing
-end
-
 # Single character conversion
 
 @inline function _convert_utf_n(::Type{C}, ch::UInt32) where {C<:UTF16CSE}

--- a/src/utf16.jl
+++ b/src/utf16.jl
@@ -26,7 +26,7 @@ function _length(::CodeUnitMulti, str::T) where {T<:Str{UTF16CSE,Nothing}}
     pnt - CHUNKSZ == fin ? cnt : (cnt - count_ones(_get_masked(pnt) & _mask_bytes(siz)))
 end
 
-function isascii(str::T) where {T<:Str{<:Union{Text2CSE, UCS2CSE, UTF16CSE},Nothing}}
+function is_ascii(str::T) where {T<:Str{<:Union{Text2CSE, UCS2CSE, UTF16CSE},Nothing}}
     (siz = sizeof(str)) == 0 && return true
     siz < CHUNKSZ &&
         return ((unsafe_load(_pnt64(str)) & _mask_bytes(siz)) & _ascii_mask(UInt16)) == 0
@@ -37,7 +37,7 @@ function isascii(str::T) where {T<:Str{<:Union{Text2CSE, UCS2CSE, UTF16CSE},Noth
     pnt - CHUNKSZ == fin || ((unsafe_load(pnt) & _mask_bytes(siz)) & _ascii_mask(UInt16)) == 0
 end
 
-function islatin(str::T) where {T<:Str{<:Union{Text2CSE, UCS2CSE, UTF16CSE},Nothing}}
+function is_latin(str::T) where {T<:Str{<:Union{Text2CSE, UCS2CSE, UTF16CSE},Nothing}}
     (siz = sizeof(str)) == 0 && return true
     siz < CHUNKSZ &&
         return ((unsafe_load(_pnt64(str)) & _mask_bytes(siz)) & _latin_mask(UInt16)) == 0
@@ -49,7 +49,7 @@ function islatin(str::T) where {T<:Str{<:Union{Text2CSE, UCS2CSE, UTF16CSE},Noth
 end
 
 # Check for any surrogate characters
-function isbmp(str::T) where {T<:Str{UTF16CSE,Nothing}}
+function is_bmp(str::T) where {T<:Str{UTF16CSE,Nothing}}
     (siz = sizeof(str)) == 0 && return true
     siz < CHUNKSZ && return (_get_masked(_pnt64(str)) & _mask_bytes(siz)) == 0
 
@@ -60,9 +60,9 @@ function isbmp(str::T) where {T<:Str{UTF16CSE,Nothing}}
     pnt - CHUNKSZ == fin || (_get_masked(pnt) & _mask_bytes(siz)) == 0
 end
 
-isascii(str::Str{_UCS2CSE}) = false
-islatin(str::Str{_UCS2CSE}) = false
-isbmp(str::UCS2Strings) = true
+is_ascii(str::Str{_UCS2CSE}) = false
+is_latin(str::Str{_UCS2CSE}) = false
+is_bmp(str::UCS2Strings) = true
 
 # Speed this up accessing 64 bits at a time
 @propagate_inbounds function _cnt_non_bmp(len, pnt::Ptr{UInt16})
@@ -95,9 +95,9 @@ end
      : (T(ch), pos + 1))
 end
 
-@propagate_inbounds @inline function _thisind(::CodeUnitMulti, str::Str{<:UTF16CSE}, pos::Int)
-    @boundscheck 1 <= pos <= _len(str) || boundserr(str, pos)
-    pos - is_surrogate_trail(get_codeunit(_pnt(str), pos))
+@propagate_inbounds @inline function _thisind(::CodeUnitMulti, str::Str{UTF16CSE}, len, pnt, pos)
+    @boundscheck 1 <= pos <= len || boundserr(str, pos)
+    pos - is_surrogate_trail(get_codeunit(pnt, pos))
 end
 
 @propagate_inbounds @inline function _nextind(::CodeUnitMulti, str::Str{<:UTF16CSE}, pos::Int)
@@ -142,14 +142,14 @@ end
 @inline _isvalid_char_pos(::CodeUnitMulti, str::Str{<:UTF16CSE}, pos::Integer) =
     !is_surrogate_trail(get_codeunit(_pnt(str), pos))
 
-function isvalid(::Type{<:UCS2Strings}, data::AbstractArray{UInt16})
+function is_valid(::Type{<:UCS2Strings}, data::AbstractArray{UInt16})
     @inbounds for ch in data
         is_surrogate_codeunit(ch) && return false
     end
     true
 end
 
-function isvalid(::Type{<:UCS2Strings}, pnt::Ptr{UInt16}, len)
+function is_valid(::Type{<:UCS2Strings}, pnt::Ptr{UInt16}, len)
     pos = 0
     @inbounds while (pos += 1) < len # check for surrogates
         is_surrogate_codeunit(get_codeunit(pnt, pos)) && return false
@@ -171,20 +171,20 @@ end
 end
 
 convert(::Type{<:Str{C}}, ch::Unsigned) where {C<:UTF16CSE} =
-    (isunicode(ch)
+    (is_unicode(ch)
      ? (ch <= 0xffff ? _convert(UTF16CSE, ch%UInt16) : _convert_utf_n(C, ch%UInt32))
      : unierror(UTF_ERR_INVALID, 0, ch))
 
 # Type _UCS2CSE must have at least 1 character > 0xff, so use other types as well
 convert(::Type{<:Str{_UCS2CSE}}, ch::Unsigned) =
     (ch > 0xff
-     ? (isbmp(ch) ? _convert(_UCS2CSE, ch%UInt16) : unierror(UTF_ERR_INVALID, 0, ch))
+     ? (is_bmp(ch) ? _convert(_UCS2CSE, ch%UInt16) : unierror(UTF_ERR_INVALID, 0, ch))
      : _convert(_LatinCSE, ch%UInt8))
 
 function convert(::Type{<:Str{C}}, str::AbstractString) where {C<:UCS2_CSEs}
-    isempty(str) && return empty_str(C)
+    is_empty(str) && return empty_str(C)
     # Might want to have an invalids_as argument
-    len, flags, num4byte = unsafe_checkstring(str)
+    len, flags, num4byte = unsafe_check_string(str)
     num4byte == 0 || unierror(UTF_ERR_INVALID_UCS2)
     buf, pnt = _allocate(UInt16, len)
     @inbounds for ch in str
@@ -199,7 +199,7 @@ function convert(::Type{<:Str{C}}, str::String) where {C<:UCS2_CSEs}
     # handle zero length string quickly
     (siz = sizeof(str)) == 0 && return empty_str(C)
     # Check that is correct UTF-8 encoding and get number of words needed
-    len, flags, num4byte = unsafe_checkstring(str, 1, siz)
+    len, flags, num4byte = unsafe_check_string(str, 1, siz)
     num4byte == 0 || unierror(UTF_ERR_INVALID_UCS2)
     # Optimize case where no characters > 0x7f
     Str(C, flags == 0 ? _cvtsize(UInt16, str, len) : _encode_utf16(str, len))
@@ -214,11 +214,11 @@ function convert(::Type{<:Str{C}}, str::Str{UTF16CSE}) where {C<:UCS2_CSEs}
     # handle zero length string quickly
     (siz = sizeof(str)) == 0 && return empty_str(C)
     # Check if conversion is valid
-    isbmp(str) || unierror(UTF_ERR_INVALID_UCS2)
+    is_bmp(str) || unierror(UTF_ERR_INVALID_UCS2)
     Str(C, _cvtsize(UInt16, _pnt(str), len))
 end
 
-function isvalid(::Type{<:Str{UTF16CSE}}, data::AbstractArray{UInt16})
+function is_valid(::Type{<:Str{UTF16CSE}}, data::AbstractArray{UInt16})
     pos = 0
     len = length(data)
     @inbounds while (pos += 1) < len # check for unpaired surrogates
@@ -232,7 +232,7 @@ end
 
 # This can be sped up, to check 4 words at a time, only checking for unpaired
 # or out of order surrogates when one is found in the UInt64
-function isvalid(::Type{<:Str{UTF16CSE}}, data::Ptr{UInt16}, len)
+function is_valid(::Type{<:Str{UTF16CSE}}, data::Ptr{UInt16}, len)
     i = 1
     @inbounds while i < len # check for unpaired surrogates
         ch = get_codeunit(data, i)
@@ -248,8 +248,8 @@ function isvalid(::Type{<:Str{UTF16CSE}}, data::Ptr{UInt16}, len)
 end
 
 function convert(::Type{<:Str{UTF16CSE}}, str::AbstractString)
-    isempty(str) && return empty_utf16
-    len, flags, num4byte = unsafe_checkstring(str)
+    is_empty(str) && return empty_utf16
+    len, flags, num4byte = unsafe_check_string(str)
     buf, pnt = _allocate(UInt16, len + num4byte)
     @inbounds for ch in str
         c = ch%UInt32
@@ -267,16 +267,16 @@ end
 
 function convert(::Type{<:Str{UTF16CSE}}, str::String)
     # handle zero length string quickly
-    isempty(str) && return empty_utf16
+    is_empty(str) && return empty_utf16
     # Check that is correct UTF-8 encoding and get number of words needed
-    len, flags, num4byte = unsafe_checkstring(str, 1, sizeof(str))
+    len, flags, num4byte = unsafe_check_string(str, 1, sizeof(str))
     # Optimize case where no characters > 0x7f
     Str(UTF16CSE, flags == 0 ? _cvtsize(UInt16, str, len) : _encode_utf16(str, len + num4byte))
 end
 
 function convert(::Type{<:Str{UTF16CSE}}, str::Str{UTF8CSE})
     # handle zero length string quickly
-    isempty(str) && return empty_utf16
+    is_empty(str) && return empty_utf16
     pnt = _pnt(str)
     len, flags, num4byte = count_chars(UTF8Str, pnt, _len(str))
     # Optimize case where no characters > 0x7f
@@ -385,14 +385,14 @@ end
 
 # Todo: Some of these need to be fixed to account for SubStr, when that is added
 convert(::Type{T},  str::S) where {T<:UCS2Strings, S<:UCS2Strings} = str
-convert(::Type{UTF16Str}, str::UTF16Str) = str
+#convert(::Type{UTF16Str}, str::UTF16Str) = str
 convert(::Type{UTF16Str}, str::UCS2Strings) = Str(UTF16CSE, str.data)
 
 unsafe_convert(::Type{Ptr{UInt16}}, s::Str{UTF16CSE}) = _pnt(s)
 
 function convert(::Type{UTF16Str}, dat::AbstractVector{UInt16})
-    isempty(dat) && return empty_utf16
-    len, flags, num4byte = unsafe_checkstring(dat, 1, lastindex(dat))
+    is_empty(dat) && return empty_utf16
+    len, flags, num4byte = unsafe_check_string(dat, 1, lastindex(dat))
     # Optimize case where no surrogate characters
     Str(UTF16CSE, flags == 0 ? _cvtsize(UInt16, dat, len) : _encode_utf16(dat, len + num4byte))
 end
@@ -412,7 +412,7 @@ function _convert(pnt::Ptr{T}, len) where {T}
 end
 
 function convert(::Type{UTF16Str}, bytes::AbstractArray{UInt8})
-    isempty(bytes) && return empty_utf16
+    is_empty(bytes) && return empty_utf16
     # Note: there are much better ways of detecting what the likely encoding is here,
     # this only deals with big or little-ending UTF-32
     # It really should detect at a minimum UTF-8, UTF-16 big and little
@@ -425,7 +425,7 @@ function convert(::Type{UTF16Str}, bytes::AbstractArray{UInt8})
     else
         buf, out = _convert(reinterpret(Ptr{UInt16}, pnt), len, swappedtype(UInt16))
     end
-    isvalid(UTF16Str, out, len) || unierror(UTF_ERR_INVALID, 0, 0)
+    is_valid(UTF16Str, out, len) || unierror(UTF_ERR_INVALID, 0, 0)
     Str(UTF16CSE, buf)
 end
 

--- a/src/utf16case.jl
+++ b/src/utf16case.jl
@@ -42,7 +42,7 @@ function lowercase(str::Str{UTF16CSE})
         prv = pnt
         (ch > 0xd7ff # May be surrogate pair
          ? _isupper_u(ch > 0xdfff ? ch%UInt32 : get_supplementary(ch, get_codeunit(pnt += 2)))
-         : (isascii(ch) ? _isupper_a(ch) : (islatin(ch) ? _isupper_l(ch) : _isupper_u(ch)))) &&
+         : (is_ascii(ch) ? _isupper_a(ch) : (is_latin(ch) ? _isupper_l(ch) : _isupper_u(ch)))) &&
              return _lower(UTF16Str, beg, prv-beg, _len(str))
         pnt += 2
     end
@@ -56,9 +56,9 @@ function _upper(::Type{<:Str{UTF16CSE}}, beg, off, len)
     out += off
     while out < fin
         ch = get_codeunit(out)
-        if isascii(ch)
+        if is_ascii(ch)
             _islower_a(ch) && set_codeunit!(out, ch -= 0x20)
-        elseif islatin(ch)
+        elseif is_latin(ch)
             if _can_upper_l(ch)
                 set_codeunit!(out, ch -= 0x20)
             elseif ch == 0xb5

--- a/src/utf16search.jl
+++ b/src/utf16search.jl
@@ -5,38 +5,36 @@ Copyright 2017-2018 Gandalf Software, Inc., Scott P. Jones
 Licensed under MIT License, see LICENSE.md
 =#
 
-function _srch_utf16_fwd(beg, ch, pnt, fin)
-    lead, trail = get_utf16(ch)
-    while pnt < fin
-        # This checks for the trailing surrogate, since they are much less like to match
-        # (there are only a few leading surrogates for the assigned areas in the non-BMP planes)
-        get_codeunit(pnt) == trail && get_codeunit(pnt - 2) == lead &&
-            return chrdiff(pnt, beg)
-        pnt += sizeof(UInt16)
+function _srch_cp(::Fwd, ::CodeUnitMulti, str::Str{UTF16CSE}, cp::AbsChar, pos, len)
+    @preserve str begin
+        beg = _pnt(str)
+        (ch = tobase(cp)) <= 0x0ffff && return _srch_codeunit(Fwd(), beg, ch%UInt16, pos, len)
+        pnt = bytoff(beg, pos)
+        fin = bytoff(beg, len)
+        lead, trail = get_utf16(ch)
+        while pnt < fin
+            # This checks for the trailing surrogate, since they are much less like to match
+            # (there are only a few leading surrogates for the assigned areas in the non-BMP
+            # planes)
+            get_codeunit(pnt) == trail && get_codeunit(pnt - 2) == lead &&
+                return chrdiff(pnt, beg)
+            pnt += sizeof(UInt16)
+        end
+        0
     end
-    0
 end
 
-function _srch_utf16_rev(beg, ch, pnt)
-    lead, trail = get_utf16(ch)
-    beg += sizeof(T) # Need to have room for lead
-    while pnt > beg
-        get_codeunit(pnt -= 2) == trail && get_codeunit(pnt -= 2) == lead &&
-            return chrdiff(pnt, beg) + 1
+function _srch_cp(::Rev, ::CodeUnitMulti, str::Str{UTF16CSE}, cp::AbsChar, pos, len)
+    @preserve str begin
+        beg = _pnt(str)
+        (ch = tobase(cp)) <= 0x0ffff && _srch_codeunit(Rev(), beg, ch%UInt16, pos)
+        pnt = bytoff(beg, pos)
+        lead, trail = get_utf16(ch)
+        beg += sizeof(UInt16) # Need to have room for lead
+        while pnt > beg
+            get_codeunit(pnt -= 2) == trail && get_codeunit(pnt -= 2) == lead &&
+                return chrdiff(pnt, beg) + 1
+        end
+        0
     end
-    0
-end
-
-function _srch_cp(::Fwd, str::Str{UTF16CSE}, cp::AbsChar, pos, len)
-    beg = _pnt(str)
-    ((ch = tobase(cp)) <= 0x0ffff
-     ? _srch_codeunit(Fwd(), beg, ch%UInt16, pos, len)
-     : _srch_utf16_fwd(beg, ch, bytoff(beg, pos), bytoff(beg, len)))
-end
-
-function _srch_cp(::Rev, str::Str{UTF16CSE}, cp::AbsChar, pos, len)
-    beg = _pnt(str)
-    ((ch = tobase(cp)) <= 0x0ffff
-     ? _srch_codeunit(Rev(), beg, ch%UInt16, pos)
-     : _srch_utf16_rev(beg, ch, bytoff(beg, pos)))
 end

--- a/src/utf8.jl
+++ b/src/utf8.jl
@@ -80,14 +80,15 @@ end
 
 ## required core functionality ##
 
+utf_trail(c::UInt8) = (0xe5000000 >>> ((c & 0xf0) >> 3)) & 0x3
+
 function lastindex(str::Str{UTF8CSE})
     (len = _len(str)) == 0 && return len
-    pnt = _pnt(str) + len
+    beg = _pnt(str)
+    pnt = beg + len
     while is_valid_continuation(get_codeunit(pnt -= 1)) ; end
-    pnt - _pnt(str) + 1
+    Int(pnt + 1 - beg)
 end
-
-utf_trail(c::UInt8) = (0xe5000000 >>> ((c & 0xf0) >> 3)) & 0x3
 
 #=
 _cont(byt, n) = (byt >>> n)%UInt8 != 0x80

--- a/src/utf8.jl
+++ b/src/utf8.jl
@@ -66,18 +66,6 @@ end
 @inline eq_bytes(pnt, b1, b2)     = get_codeunit(pnt+1) == b2 && eq_bytes(pnt, b1)
 @inline eq_bytes(pnt, b1, b2, b3) = get_codeunit(pnt+2) == b3 && eq_bytes(pnt, b1, b2)
 
-@inline _write_utf8_2(io, ch) = write(io, get_utf8_2(ch)...)
-@inline _write_utf8_3(io, ch) = write(io, get_utf8_3(ch)...)
-@inline _write_utf8_4(io, ch) = write(io, get_utf8_4(ch)...)
-
-@inline _write_ucs2(io, ch) =
-    ch <= 0x7f ? write(io, ch%UInt8) : ch <= 0x7ff ? _write_utf8_2(io, ch) : _write_utf8_3(io, ch)
-
-@inline _write_utf32(io, ch) = ch <= 0xffff ? _write_ucs2(io, ch) : _write_utf8_4(io, ch)
-
-@inline print(io::IO, ch::UCS2Chr)  = _write_ucs2(io, tobase(ch))
-@inline print(io::IO, ch::UTF32Chr) = _write_utf32(io, tobase(ch))
-
 ## required core functionality ##
 
 utf_trail(c::UInt8) = (0xe5000000 >>> ((c & 0xf0) >> 3)) & 0x3

--- a/src/utf8.jl
+++ b/src/utf8.jl
@@ -1,7 +1,9 @@
 #=
 UTF8Str type
 
-Copyright 2017 Gandalf Software, Inc., Scott P. Jones, and other contributors to the Julia language
+Copyright 2017-2018 Gandalf Software, Inc., Scott P. Jones,
+and other contributors to the Julia language
+
 Licensed under MIT License, see LICENSE.md
 Based in part on code for UTF8String that used to be in Julia
 =#
@@ -304,11 +306,9 @@ const _ByteStr = Union{Str{ASCIICSE}, Str{UTF8CSE}, String}
 string(c::_ByteStr...) = length(c) == 1 ? c[1]::UTF8Str : UTF8Str(_string(c))
     # ^^ at least one must be UTF-8 or the ASCII-only method would get called
 
-function reverse(str::Str{UTF8CSE})
-    (len = _len(str)) < 2 && return str
-    buf, beg = _allocate(UInt8, len)
+function _reverse(::CodeUnitMulti, ::Type{UTF8CSE}, len, pnt::Ptr{T}) where {T<:CodeUnitTypes}
+    buf, beg = _allocate(T, len)
     out = beg + len
-    pnt = _pnt(str)
     while out >= beg
         ch = get_codeunit(pnt)
         if ch > 0xdf

--- a/src/utf8.jl
+++ b/src/utf8.jl
@@ -287,7 +287,7 @@ end
 
 @propagate_inbounds function getindex(str::Str{UTF8CSE}, rng::UnitRange{Int})
     isempty(rng) && return SubString(empty_utf8, 1, 0)
-    beg = first(rng) 
+    beg = first(rng)
     len = _len(str)
     @boundscheck 1 <= beg <= len || boundserr(str, beg)
     pnt = _pnt(str)
@@ -296,7 +296,7 @@ end
     lst = last(rng)
     @boundscheck lst > len && boundserr(str, lst)
     if lst != len
-        ch = get_codeunit(pnt + lst)
+        ch = get_codeunit(pnt, lst)
         is_valid_continuation(ch) && unierror(UTF_ERR_INVALID_INDEX, lst, ch)
     end
     SubString(str, beg, lst)

--- a/src/utf8proc.jl
+++ b/src/utf8proc.jl
@@ -1,0 +1,199 @@
+# This file includes code originally part of Julia.n
+# Licensed under MIT License, see LICENSE.md
+
+# The plan is to rewrite all of the functionality to not use the utf8proc library,
+# and to use tables loaded up on initialization, as with StringLiterals.jl
+
+# Currently, for characters outside the Latin1 subset, this depends on the following C calls:
+# utf8proc_decompose
+# utf8proc_reencode
+# utf8proc_charwidth
+# utf8proc_category
+# utf8proc_category_string
+# utf8proc_tolower
+# utf8proc_toupper
+# utf8proc_totitle
+
+# For grapheme segmentation, this currently depends on the following 2 C calls:
+# utf8proc_grapheme_break
+# utf8proc_grapheme_break_stateful
+
+# Unicode category constants
+module Uni
+const CN = 0
+const LU = 1
+const LL = 2
+const LT = 3
+const LM = 4
+const LO = 5
+const MN = 6
+const MC = 7
+const ME = 8
+const ND = 9
+const NL = 10
+const NO = 11
+const PC = 12
+const PD = 13
+const PS = 14
+const PE = 15
+const PI = 16
+const PF = 17
+const PO = 18
+const SM = 19
+const SC = 20
+const SK = 21
+const SO = 22
+const ZS = 23
+const ZL = 24
+const ZP = 25
+const CC = 26
+const CF = 27
+const CS = 28
+const CO = 29
+
+# strings corresponding to the category constants
+const catstrings = [
+    "Other, not assigned",
+    "Letter, uppercase",
+    "Letter, lowercase",
+    "Letter, titlecase",
+    "Letter, modifier",
+    "Letter, other",
+    "Mark, nonspacing",
+    "Mark, spacing combining",
+    "Mark, enclosing",
+    "Number, decimal digit",
+    "Number, letter",
+    "Number, other",
+    "Punctuation, connector",
+    "Punctuation, dash",
+    "Punctuation, open",
+    "Punctuation, close",
+    "Punctuation, initial quote",
+    "Punctuation, final quote",
+    "Punctuation, other",
+    "Symbol, math",
+    "Symbol, currency",
+    "Symbol, modifier",
+    "Symbol, other",
+    "Separator, space",
+    "Separator, line",
+    "Separator, paragraph",
+    "Other, control",
+    "Other, format",
+    "Other, surrogate",
+    "Other, private use",
+    "Invalid, too high",
+    "Malformed, bad data",
+]
+
+const STABLE    = 1<<1
+const COMPAT    = 1<<2
+const COMPOSE   = 1<<3
+const DECOMPOSE = 1<<4
+const IGNORE    = 1<<5
+const REJECTNA  = 1<<6
+const NLF2LS    = 1<<7
+const NLF2PS    = 1<<8
+const NLF2LF    = NLF2LS | NLF2PS
+const STRIPCC   = 1<<9
+const CASEFOLD  = 1<<10
+const CHARBOUND = 1<<11
+const LUMP      = 1<<12
+const STRIPMARK = 1<<13
+end
+
+############################################################################
+
+utf8proc_error(result) =
+    error(unsafe_string(ccall(:utf8proc_errmsg, Cstring, (Cssize_t,), result)))
+
+function utf8proc_map(::Type{T}, str, options::Integer) where {T<:Str}
+    nwords = ccall(:utf8proc_decompose, Int, (Ptr{UInt8}, Int, Ptr{UInt8}, Int, Cint),
+                   str, sizeof(str), C_NULL, 0, options)
+    nwords < 0 && utf8proc_error(nwords)
+    buffer = _allocate(nwords*4)
+    nwords = ccall(:utf8proc_decompose, Int, (Ptr{UInt8}, Int, Ptr{UInt8}, Int, Cint),
+                   str, sizeof(str), buffer, nwords, options)
+    nwords < 0 && utf8proc_error(nwords)
+    nbytes = ccall(:utf8proc_reencode, Int, (Ptr{UInt8}, Int, Cint), buffer, nwords, options)
+    nbytes < 0 && utf8proc_error(nbytes)
+    T(resize!(buffer, nbytes))
+end
+
+utf8proc_charwidth(ch) = Int(ccall(:utf8proc_charwidth, Cint, (UInt32,), ch))
+
+utf8proc_map(str::T, options::Integer) where {T<:Str} = utf8proc_map(T, UTF8Str(str), options)
+utf8proc_map(str::Str{UTF8CSE}, options::Integer) = utf8proc_map(UTF8Str, str, options)
+
+@inline utf8proc_cat(ch) = ccall(:utf8proc_category, Cint, (UInt32,), ch)
+@inline utf8proc_cat_abbr(ch) =
+    unsafe_string(ccall(:utf8proc_category_string, Cstring, (UInt32,), ch))
+
+@inline _lowercase_u(ch) = ccall(:utf8proc_tolower, UInt32, (UInt32,), ch)
+@inline _uppercase_u(ch) = ccall(:utf8proc_toupper, UInt32, (UInt32,), ch)
+@inline _titlecase_u(ch) = ccall(:utf8proc_totitle, UInt32, (UInt32,), ch)
+
+############################################################################
+
+function _normalize(::Type{T}, str::AbstractString;
+                   stable::Bool      = false,
+                   compat::Bool      = false,
+                   compose::Bool     = true,
+                   decompose::Bool   = false,
+                   stripignore::Bool = false,
+                   rejectna::Bool    = false,
+                   newline2ls::Bool  = false,
+                   newline2ps::Bool  = false,
+                   newline2lf::Bool  = false,
+                   stripcc::Bool     = false,
+                   casefold::Bool    = false,
+                   lump::Bool        = false,
+                   stripmark::Bool   = false,
+                   ) where {T<:Str}
+    (compose & decompose) && unierror(UTF_ERR_DECOMPOSE_COMPOSE)
+    (!(compat | stripmark) & (compat | stripmark)) && unierror(UTF_ERR_COMPAT_STRIPMARK)
+    newline2ls + newline2ps + newline2lf > 1 && unierror(UTF_ERR_NL_CONVERSION)
+    flags =
+        ifelse(stable,      Uni.STABLE, 0) |
+        ifelse(compat,      Uni.COMPAT, 0) |
+        ifelse(decompose,   Uni.DECOMPOSE, 0) |
+        ifelse(compose,     Uni.COMPOSE, 0) |
+        ifelse(stripignore, Uni.IGNORE, 0) |
+        ifelse(rejectna,    Uni.REJECTNA, 0) |
+        ifelse(newline2ls,  Uni.NLF2LS, 0) |
+        ifelse(newline2ps,  Uni.NLF2PS, 0) |
+        ifelse(newline2lf,  Uni.NLF2LF, 0) |
+        ifelse(stripcc,     Uni.STRIPCC, 0) |
+        ifelse(casefold,    Uni.CASEFOLD, 0) |
+        ifelse(lump,        Uni.LUMP, 0) |
+        ifelse(stripmark,   Uni.STRIPMARK, 0)
+    T(utf8proc_map(str, flags))
+end
+
+normalize(str::T, options::Integer) where {T<:Str} = _normalize(T, UTF8Str(str), options)
+normalize(str::Str{UTF8CSE}, options::Integer) = _normalize(UTF8Str, str, options)
+
+normalize(str::Str, nf::Symbol) =
+    utf8proc_map(str, nf == :NFC ? (Uni.STABLE | Uni.COMPOSE) :
+                 nf == :NFD ? (Uni.STABLE | Uni.DECOMPOSE) :
+                 nf == :NFKC ? (Uni.STABLE | Uni.COMPOSE | Uni.COMPAT) :
+                 nf == :NFKD ? (Uni.STABLE | Uni.DECOMPOSE | Uni.COMPAT) :
+                 unierror(UTF_ERR_NORMALIZE, nf))
+
+############################################################################
+
+# iterators for grapheme segmentation
+
+is_grapheme_break(c1::CodePointTypes, c2::CodePointTypes) =
+    !(c1 <= 0x10ffff && c2 <= 0x10ffff) ||
+    ccall(:utf8proc_grapheme_break, Bool, (UInt32, UInt32), c1, c2)
+
+# Stateful grapheme break required by Unicode-9 rules: the string
+# must be processed in sequence, with state initialized to Ref{Int32}(0).
+# Requires utf8proc v2.0 or later.
+is_grapheme_break!(state::Ref{Int32}, c1::CodePointTypes, c2::CodePointTypes) =
+    ((c1 <= 0x10ffff && c2 <= 0x10ffff)
+     ? ccall(:utf8proc_grapheme_break_stateful, Bool, (UInt32, UInt32, Ref{Int32}), c1, c2, state)
+     : (state[] = 0; true))
+

--- a/src/utf8search.jl
+++ b/src/utf8search.jl
@@ -4,68 +4,58 @@ Optimized search functions for UTFStr (UTF-8 encoding)
 Copyright 2017-2018 Gandalf Software, Inc., Scott P. Jones
 Licensed under MIT License, see LICENSE.md
 =#
-function _srch_utf8_fwd(beg, ch, pnt, fin)
-    if ch <= 0x7ff
-        b1, b2 = get_utf8_2(ch)
-        while (pnt = _fwd_memchr(pnt + 1, b2, fin)) != C_NULL
-            eq_bytes(pnt - 1, b1) && return Int(pnt - beg)
+function _srch_cp(::Fwd, ::CodeUnitMulti, str::Str{UTF8CSE}, cp::AbsChar, pos, len)
+    @preserve str begin
+        (ch = tobase(cp)) < 0x80 && return _srch_codeunit(Fwd(), _pnt(str), ch%UInt8, pos, len)
+        beg = _pnt(str)
+        pnt = beg + pos - 1
+        fin = beg + len
+        if ch <= 0x7ff
+            b1, b2 = get_utf8_2(ch)
+            while (pnt = _fwd_memchr(pnt + 1, b2, fin)) != C_NULL
+                eq_bytes(pnt - 1, b1) && return Int(pnt - beg)
+            end
+        elseif ch <= 0xffff
+            b1, b2, b3 = get_utf8_3(ch)
+            pnt += 1
+            while (pnt = _fwd_memchr(pnt + 1, b3, fin)) != C_NULL
+                eq_bytes(pnt - 2, b1, b2) && return Int(pnt - beg) - 1
+            end
+        else
+            b1, b2, b3, b4 = get_utf8_4(ch)
+            pnt += 2
+            while (pnt = _fwd_memchr(pnt + 1, b4, fin)) != C_NULL
+                eq_bytes(pnt - 3, b1, b2, b3) && return Int(pnt - beg) - 2
+            end
         end
-    elseif ch <= 0xffff
-        b1, b2, b3 = get_utf8_3(ch)
-        pnt += 1
-        while (pnt = _fwd_memchr(pnt + 1, b3, fin)) != C_NULL
-            eq_bytes(pnt - 2, b1, b2) && return Int(pnt - beg) - 1
-        end
-    else
-        b1, b2, b3, b4 = get_utf8_4(ch)
-        pnt += 2
-        println("beg=$beg, pnt=$pnt, fin=$fin, ch=$ch, $b1,$b2,$b3,$b4")
-        while (pnt = _fwd_memchr(pnt + 1, b4, fin)) != C_NULL
-            println(" => $pnt")
-            eq_bytes(pnt - 3, b1, b2, b3) && return Int(pnt - beg) - 2
-        end
+        0
     end
+end
+
+function _srch_cp(::Rev, ::CodeUnitMulti, str::Str{UTF8CSE}, cp::AbsChar, pos, len)
+    @preserve str begin
+        (ch = tobase(cp)) < 0x80 && return _srch_codeunit(Rev(), _pnt(str), ch%UInt8, pos)
+        init = beg = _pnt(str)
+        pnt = beg + @inbounds nextind(str, pos) - 1
+        if ch <= 0x7ff
+            b1, b2 = get_utf8_2(ch)
+            beg += 1
+            while pnt > beg && (pnt = _rev_memchr(beg, b2, pnt + 1)) != C_NULL
+                eq_bytes(pnt - 1, b1) && return Int(pnt - init)
+            end
+        elseif ch <= 0xffff
+            b1, b2, b3 = get_utf8_3(ch)
+            beg += 2
+            while pnt > beg && (pnt = _rev_memchr(beg, b3, pnt + 1)) != C_NULL
+                eq_bytes(pnt - 2, b1, b2) && return Int(pnt - 1 - init)
+            end
+        else
+            b1, b2, b3, b4 = get_utf8_4(ch)
+            start = beg + 3
+            while pnt > beg && (pnt = _rev_memchr(beg, b4, pnt + 1)) != C_NULL
+                eq_bytes(pnt - 3, b1, b2, b3) && return Int(pnt - 2 - init)
+            end
+        end
     0
-end
-
-function _srch_cp(::Fwd, str::Str{UTF8CSE}, cp::AbsChar, pos, len)
-    beg = _pnt(str)
-    is_valid_continuation(get_codeunit(beg, pos)) && index_error(str, pos)
-    ((ch = tobase(cp)) < 0x80
-     ? _srch_codeunit(Fwd(), beg, ch%UInt8, pos, len)
-     : _srch_utf8_fwd(beg, ch, beg + pos - 1, beg + len))
-end
-
-function _srch_utf8_rev(beg, ch, pnt)
-    if ch <= 0x7ff
-        b1, b2 = get_utf8_2(ch)
-        beg += 1
-        while (pnt = _rev_memchr(beg, b2, pnt)) != C_NULL
-            eq_bytes(pnt, b1) && return Int(pnt - beg) + 1
-            pnt -= 1 > beg || break
-        end
-    elseif ch <= 0xffff
-        b1, b2, b3 = get_utf8_3(ch)
-        beg += 2
-        while (pnt = _rev_memchr(beg, b3, pnt)) != C_NULL
-            eq_bytes(pnt, b1, b2) && return Int(pnt - beg) + 2
-            pnt -= 1 > beg || break
-        end
-    else
-        b1, b2, b3, b4 = get_utf8_4(ch)
-        beg += 3
-        while (pnt = _rev_memchr(beg, b4, pnt)) != C_NULL
-            eq_bytes(pnt, b1, b2, b3) && return Int(pnt - beg) + 3
-            pnt -= 1 > beg || break
-        end
     end
-    0
-end
-
-function _srch_cp(::Rev, str::Str{UTF8CSE}, cp::AbsChar, pos, len)
-    beg = _pnt(str)
-    is_valid_continuation(get_codeunit(beg + pos - 1)) && index_error(str, pos)
-    ((ch = tobase(cp)) < 0x80
-     ? _srch_codeunit(Rev(), beg, ch%UInt8, pos)
-     : _srch_utf8_rev(beg, ch, beg + pos))
 end

--- a/src/utf8search.jl
+++ b/src/utf8search.jl
@@ -36,7 +36,7 @@ function _srch_cp(::Rev, ::CodeUnitMulti, str::Str{UTF8CSE}, cp::AbsChar, pos, l
     @preserve str begin
         (ch = tobase(cp)) < 0x80 && return _srch_codeunit(Rev(), _pnt(str), ch%UInt8, pos)
         init = beg = _pnt(str)
-        pnt = beg + @inbounds nextind(str, pos)
+        @inbounds pnt = beg + nextind(str, pos)
         if ch <= 0x7ff
             pnt > (beg += 1) || return 0
             b1, b2 = get_utf8_2(ch)

--- a/src/util.jl
+++ b/src/util.jl
@@ -1,0 +1,215 @@
+#=
+Utility functions for Str strings
+
+Copyright 2018 Gandalf Software, Inc., Scott P. Jones, and other contributors to the Julia language
+Licensed under MIT License, see LICENSE.md
+Based initially on julia/test/strings/util.jl
+=#
+
+using Base: Chars, _default_delims
+
+# starts with and ends with predicates
+
+@static if false
+
+#Todo: Make fast version for Str, using CompareStyle & Contains
+
+function startswith(a::AbstractString, b::AbstractString)
+    a, b = Iterators.Stateful(a), Iterators.Stateful(b)
+    all(splat(==), zip(a, b)) && isempty(b)
+end
+startswith(str::AbstractString, chars::Chars) = !isempty(str) && first(str) in chars
+
+function endswith(a::AbstractString, b::AbstractString)
+    a = Iterators.Stateful(Iterators.reverse(a))
+    b = Iterators.Stateful(Iterators.reverse(b))
+    all(splat(==), zip(a, b)) && isempty(b)
+end
+endswith(str::AbstractString, chars::Chars) = !isempty(str) && last(str) in chars
+end
+
+startswith(a::Str{C}, b::Str{C}) where {C<:CSE} =
+    (len = _len(b)) <= _len(a) && _memcmp(_pnt(a), _pnt(b), len) == 0
+
+endswith(a::Str{C}, b::Str{C}) where {C<:CSE} =
+    (lenb = _len(b)) <= (lena = _len(a)) && _memcmp(_pnt(a) + lena - lenb, _pnt(b), lenb) == 0
+
+@static if false
+function chop(s::AbstractString; head::Integer = 0, tail::Integer = 1)
+    SubString(s, nextind(s, firstindex(s), head), prevind(s, lastindex(s), tail))
+end
+end
+
+function chomp(str::Str)
+    len, pnt = _lenpnt(str)
+    SubStr(str, 1,
+           ((len <= 0 || get_codeunit(pnt + len - 1) != 0x0a)
+            ? len : (len - 1 + (len < 2 || get_codeunit(pnt + len - 2) != 0x0d))))
+end
+
+@static if false
+function lstrip(s::AbstractString, chars::Chars=_default_delims)
+    e = lastindex(s)
+    for (i, c) in pairs(s)
+        !(c in chars) && return SubString(s, i, e)
+    end
+    SubString(s, e+1, e)
+end
+
+function rstrip(s::AbstractString, chars::Chars=_default_delims)
+    for (i, c) in Iterators.reverse(pairs(s))
+        c in chars || return SubString(s, 1, i)
+    end
+    SubString(s, 1, 0)
+end
+
+strip(s::AbstractString) = lstrip(rstrip(s))
+strip(s::AbstractString, chars::Chars) = lstrip(rstrip(s, chars), chars)
+
+end # if false
+
+## string padding functions ##
+
+# Todo: make these not build two strings, and return the correct type (i.e. of the first argument)
+
+function _lpad(cnt, pad, str)
+    cnt, rem = divrem(cnt, length(pad))
+    rem == 0 ? string(pad^cnt, str) : string(pad^cnt, first(pad, rem), str)
+end
+lpad(str::Str, cnt::Integer, pad::AbstractString) =
+    (cnt -= length(str)) <= 0 ? str : _lpad(cnt, pad, str)
+lpad(ch::CodePoint, cnt::Integer, pad::AbstractString) =
+    cnt < 1 ? string(ch) : _lpad(cnt, pad, ch)
+lpad(str::Str, cnt::Integer, pad::AbsChar=' ') =
+    (len = length(str)) > cnt ? str : string(pad^cnt, str)
+lpad(ch::CodePoint, cnt::Integer, pad::AbstractChar=' ') =
+    cnt < 1 ? string(ch) : string(pad^cnt, ch)
+
+function _rpad(cnt, pad, str)
+    cnt, rem = divrem(cnt, length(pad))
+    rem == 0 ? string(str, pad^cnt) : string(str, pad^cnt, first(pad, rem))
+end
+rpad(str::Str, cnt::Integer, pad::AbstractString) =
+    (cnt -= length(str)) <= 0 ? str : _rpad(cnt, pad, str)
+rpad(ch::CodePoint, cnt::Integer, pad::AbstractString) =
+    cnt < 1 ? string(ch) : _rpad(cnt, pad, ch)
+rpad(str::Str, cnt::Integer, pad::AbsChar=' ') =
+    (len = length(str)) > cnt ? str : string(pad^cnt, str)
+rpad(ch::CodePoint, cnt::Integer, pad::AbsChar=' ') =
+    cnt < 1 ? string(ch) : string(ch, pad^cnt)
+
+split(str::T, splitter;
+      limit::Integer=0, keep::Bool=true) where {T<:Str} =
+    _split(str, splitter, limit, keep, T <: SubString ? T[] : SubString{T}[])
+split(str::T, splitter::Union{Tuple{Vararg{<:AbstractChar}},AbstractVector{<:AbstractChar},Set{<:AbstractChar}};
+      limit::Integer=0, keep::Bool=true) where {T<:Str} =
+    _split(str, occursin(splitter), limit, keep, T <: SubString ? T[] : SubString{T}[])
+split(str::T, splitter::AbstractChar;
+      limit::Integer=0, keep::Bool=true) where {T<:Str} =
+    _split(str, equalto(splitter), limit, keep, T <: SubString ? T[] : SubString{T}[])
+
+function _split(str::T, splitter, limit::Integer, keep_empty::Bool, strs::Array) where {T<:Str}
+    i = 1
+    n = lastindex(str)
+    r = find_next(splitter, str, 1)
+    if r != 0:-1
+        j, k = first(r), nextind(str,last(r))
+        while 0 < j <= n && length(strs) != limit-1
+            if i < k
+                (keep_empty || i < j) &&
+                    push!(strs, SubString(str,i,prevind(str,j)))
+                i = k
+            end
+            (k <= j) && (k = nextind(str,j))
+            r = find_next(splitter, str, k)
+            r == 0:-1 && break
+            j, k = first(r), nextind(str,last(r))
+        end
+    end
+    if keep_empty || !done(str,i)
+        push!(strs, SubString(str,i))
+    end
+    strs
+end
+
+# a bit oddball, but standard behavior in Perl, Ruby & Python:
+split(str::Str) = split(str, _default_delims; limit=0, keep=false)
+
+rsplit(str::T, splitter; limit::Integer=0, keep::Bool=true) where {T<:Str} =
+    _rsplit(str, splitter, limit, keep, T <: SubString ? T[] : SubString{T}[])
+rsplit(str::T, splitter::Union{Tuple{Vararg{<:AbstractChar}},
+                               AbstractVector{<:AbstractChar},Set{<:AbstractChar}};
+       limit::Integer=0, keep::Bool=true) where {T<:Str} =
+  _rsplit(str, occursin(splitter), limit, keep, T <: SubString ? T[] : SubString{T}[])
+rsplit(str::T, splitter::AbstractChar;
+       limit::Integer=0, keep::Bool=true) where {T<:Str} =
+  _rsplit(str, equalto(splitter), limit, keep, T <: SubString ? T[] : SubString{T}[])
+
+function _rsplit(str::Str, splitter, limit::Integer, keep_empty::Bool, strs::Array)
+    n = lastindex(str)
+    r = find_prev(splitter, str, n)
+    j, k = first(r), last(r)
+    while j > 0 && k > 0 && length(strs) != limit-1
+        (keep_empty || k < n) && pushfirst!(strs, SubString(str,nextind(str,k),n))
+        n = prevind(str, j)
+        r = find_prev(splitter, str, n)
+        j, k = first(r), last(r)
+    end
+    (keep_empty || n > 0) && pushfirst!(strs, SubString(str,1,n))
+    strs
+end
+
+_replace(io, repl, str, r, pattern) = print(io, repl)
+_replace(io, repl::Function, str, r, pattern) =
+    print(io, repl(SubString(str, first(r), last(r))))
+_replace(io, repl::Function, str, r, pattern::Function) =
+    print(io, repl(str[first(r)]))
+
+replace(str::Str, pat_repl::Pair{<:AbstractChar}; count::Integer=typemax(Int)) =
+    replace(str, equalto(first(pat_repl)) => last(pat_repl); count=count)
+
+replace(str::Str, pat_repl::Pair{<:Union{Tuple{Vararg{<:AbstractChar}},
+                                         AbstractVector{<:AbstractChar},Set{<:AbstractChar}}};
+        count::Integer=typemax(Int)) =
+    replace(str, occursin(first(pat_repl)) => last(pat_repl), count=count)
+
+function replace(str::Str, pat_repl::Pair; count::Integer=typemax(Int))
+    pattern, repl = pat_repl
+    count == 0 && return str
+    count < 0 && throw(DomainError(count, "`count` must be non-negative."))
+    n = 1
+    i = a = 1
+    e = lastindex(str)
+    r = find_next(pattern, str, 1)
+    # Just return the string if not found
+    j, k = first(r), last(r)
+    out = IOBuffer(sizehint=floor(Int, 1.2 * sizeof(str)))
+    while j != 0
+        if i == a || i <= k
+            unsafe_write(out, pointer(str, i), UInt(j-i))
+            _replace(out, repl, str, r, pattern)
+        end
+        if k < j
+            i = j
+            j > e && break
+            k = nextind(str, j)
+        else
+            i = k = nextind(str, k)
+        end
+        r = find_next(pattern, str, k)
+        r == 0:-1 || n == count && break
+        j, k = first(r), last(r)
+        n += 1
+    end
+    write(out, SubString(str,i))
+    Str(cse(str), take!(out))
+end
+
+# TODO: allow transform as the first argument to replace?
+
+ascii_err() = throw(ArgumentError("Not a valid ASCII string"))
+ascii(str::Union{T,SubString{T}}) where {T<:Str{CSE}} =
+    isascii(str) ? ASCIIStr(str) : ascii_err()
+ascii(str::Union{T,SubString{T}}) where {T<:Str{SubSet_CSEs}} = ascii_err()
+ascii(str::Union{T,SubString{T}}) where {T<:Str{ASCIICSE}} = str
+

--- a/src/util.jl
+++ b/src/util.jl
@@ -111,7 +111,7 @@ split(str::T, splitter::AbstractChar;
 function _split(str::T, splitter, limit::Integer, keep_empty::Bool, strs::Array) where {T<:Str}
     i = 1
     n = lastindex(str)
-    r = find_next(splitter, str, 1)
+    r = find(Fwd, splitter, str)
     if r != 0:-1
         j, k = first(r), nextind(str,last(r))
         while 0 < j <= n && length(strs) != limit-1
@@ -121,7 +121,7 @@ function _split(str::T, splitter, limit::Integer, keep_empty::Bool, strs::Array)
                 i = k
             end
             (k <= j) && (k = nextind(str,j))
-            r = find_next(splitter, str, k)
+            r = find(Fwd, splitter, str, k)
             r == 0:-1 && break
             j, k = first(r), nextind(str,last(r))
         end
@@ -147,12 +147,12 @@ rsplit(str::T, splitter::AbstractChar;
 
 function _rsplit(str::Str, splitter, limit::Integer, keep_empty::Bool, strs::Array)
     n = lastindex(str)
-    r = find_prev(splitter, str, n)
+    r = find(Rev, splitter, str, n)
     j, k = first(r), last(r)
     while j > 0 && k > 0 && length(strs) != limit-1
-        (keep_empty || k < n) && pushfirst!(strs, SubString(str,nextind(str,k),n))
+        (keep_empty || k < n) && pushfirst!(strs, SubString(str, nextind(str, k), n))
         n = prevind(str, j)
-        r = find_prev(splitter, str, n)
+        r = find(Rev, splitter, str, n)
         j, k = first(r), last(r)
     end
     (keep_empty || n > 0) && pushfirst!(strs, SubString(str,1,n))
@@ -178,14 +178,14 @@ function replace(str::Str, pat_repl::Pair; count::Integer=typemax(Int))
     count == 0 && return str
     count < 0 && throw(DomainError(count, "`count` must be non-negative."))
     n = 1
-    i = a = 1
+    i = 1
     e = lastindex(str)
-    r = find_next(pattern, str, 1)
+    r = fnd(Fwd, pattern, str)
     # Just return the string if not found
     j, k = first(r), last(r)
     out = IOBuffer(sizehint=floor(Int, 1.2 * sizeof(str)))
     while j != 0
-        if i == a || i <= k
+        if i == 1 || i <= k
             unsafe_write(out, pointer(str, i), UInt(j-i))
             _replace(out, repl, str, r, pattern)
         end
@@ -196,7 +196,7 @@ function replace(str::Str, pat_repl::Pair; count::Integer=typemax(Int))
         else
             i = k = nextind(str, k)
         end
-        r = find_next(pattern, str, k)
+        r = fnd(Fwd, pattern, str, k)
         r == 0:-1 || n == count && break
         j, k = first(r), last(r)
         n += 1

--- a/test/bench.jl
+++ b/test/bench.jl
@@ -459,11 +459,11 @@ function searchlines(lines, v, rev=false)
     t = 0
     if rev
     for text in lines
-        t += searchres(find_last(v, text))
+        t += searchres(fnd(Rev, v, text))
     end
     else
     for text in lines
-        t += searchres(find_first(v, text))
+        t += searchres(fnd(Fwd, v, text))
     end
     end
     t
@@ -474,25 +474,25 @@ function searchlines(lines::Vector{UniStr}, v, rev=false)
     if rev
     for text in lines
         if typeof(text) == ASCIIStr
-            t += searchres(find_last(v, text::ASCIIStr))
+            t += searchres(fnd(Rev, v, text::ASCIIStr))
         elseif typeof(text) == _LatinStr
-            t += searchres(find_last(v, text::_LatinStr))
+            t += searchres(fnd(Rev, v, text::_LatinStr))
         elseif typeof(text) == _UCS2Str
-            t += searchres(find_last(v, text::_UCS2Str))
+            t += searchres(fnd(Rev, v, text::_UCS2Str))
         else
-            t += searchres(find_last(v, text::_UTF32Str))
+            t += searchres(fnd(Rev, v, text::_UTF32Str))
         end
     end
     else
     for text in lines
         if typeof(text) == ASCIIStr
-            t += searchres(find_first(v, text::ASCIIStr))
+            t += searchres(fnd(Fwd, v, text::ASCIIStr))
         elseif typeof(text) == _LatinStr
-            t += searchres(find_first(v, text::_LatinStr))
+            t += searchres(fnd(Fwd, v, text::_LatinStr))
         elseif typeof(text) == _UCS2Str
-            t += searchres(find_first(v, text::_UCS2Str))
+            t += searchres(fnd(Fwd, v, text::_UCS2Str))
         else
-            t += searchres(find_first(v, text::_UTF32Str))
+            t += searchres(fnd(Fwd, v, text::_UTF32Str))
         end
     end
     end

--- a/test/bench.jl
+++ b/test/bench.jl
@@ -106,7 +106,7 @@ function remove_empty(lines)
     out = Vector{String}()
     sizehint!(out, len)
     for l in lines
-        isempty(l) || push!(out, l)
+        is_empty(l) || push!(out, l)
     end
     out
 end
@@ -279,7 +279,7 @@ end
 function iteratechars(text::AbstractString)
     cnt = 0
     for ch in text
-        cnt += isdigit(ch)
+        cnt += is_digit(ch)
     end
     cnt
 end
@@ -287,7 +287,7 @@ end
 function iteratecps(text::AbstractString)
     cnt = 0
     for ch in codepoints(text)
-        cnt += isdigit(ch)
+        cnt += is_digit(ch)
     end
     cnt
 end
@@ -295,7 +295,7 @@ end
 function iteratecus(text::AbstractString)
     cnt = 0
     for ch in codeunits(text)
-        cnt += isdigit(ch)
+        cnt += is_digit(ch)
     end
     cnt
 end
@@ -351,7 +351,7 @@ end
 function checktext(fun, lines::Vector{<:AbstractString})
     cnt = 0
     for text in lines
-        isempty(text) || fun(text)
+        is_empty(text) || fun(text)
         cnt += 1
     end
     cnt
@@ -573,7 +573,7 @@ repeat10c(str) = @inbounds repeat(str[1], 10)
 
 countsklength(l)  = checkstr(sklength, l)
 countoldlength(l) = checkstr(oldlength, l)
-checktextwidth(l) = checkstr(textwidth, l)
+checktextwidth(l) = checkstr(text_width, l)
 
 checkrepeat1(l)   = checktext(repeat1, l)
 checkrepeat10(l)  = checktext(repeat10, l)
@@ -586,26 +586,26 @@ countchars(l)   = checkstr(iteratechars, l)
 countcps(l)     = checkstr(iteratecps, l)
 countcus(l)     = checkstr(iteratecus, l)
 
-validstr(l)     = checkstr(isvalid, l)
-asciistr(l)     = checkstr(isascii, l)
+validstr(l)     = checkstr(is_valid, l)
+asciistr(l)     = checkstr(is_ascii, l)
 
-validchars(l)   = checkchars(isvalid, l)
-asciichars(l)   = checkchars(isascii, l)
+validchars(l)   = checkchars(is_valid, l)
+asciichars(l)   = checkchars(is_ascii, l)
 
-checkvalid(l)   = checkcp(isvalid,   l)
-checkascii(l)   = checkcp(isascii,   l)
-checkcntrl(l)   = checkcp(iscntrl,   l)
-checkdigit(l)   = checkcp(isdigit,   l)
-checkxdigit(l)  = checkcp(isxdigit,  l)
-checklower(l)   = checkcp(islower,   l)
-checkupper(l)   = checkcp(isupper,   l)
-checkalpha(l)   = checkcp(isalpha,   l)
-checknumeric(l) = checkcp(isnumeric, l)
-checkspace(l)   = checkcp(isspace,   l)
-checkalnum(l)   = checkcp(is_alnum,  l)
-checkprint(l)   = checkcp(isprint,   l)
-checkpunct(l)   = checkcp(ispunct,   l)
-checkgraph(l)   = checkcp(is_graph,  l)
+checkvalid(l)   = checkcp(is_valid,     l)
+checkascii(l)   = checkcp(is_ascii,     l)
+checkcntrl(l)   = checkcp(is_control,   l)
+checkdigit(l)   = checkcp(is_digit,     l)
+checkxdigit(l)  = checkcp(is_hex_digit, l)
+checklower(l)   = checkcp(is_lowercase, l)
+checkupper(l)   = checkcp(is_uppercase, l)
+checkalpha(l)   = checkcp(is_alpha,     l)
+checknumeric(l) = checkcp(is_numeric,   l)
+checkspace(l)   = checkcp(is_space,     l)
+checkalnum(l)   = checkcp(is_alphanumeric, l)
+checkprint(l)   = checkcp(is_printable,    l)
+checkpunct(l)   = checkcp(is_punctuation,  l)
+checkgraph(l)   = checkcp(is_graphic,      l)
 
 function mintime(f, lines)
     m = typemax(UInt)
@@ -689,8 +689,8 @@ function select_lines(lines::Vector{<:AbstractString}; num=1000)
     i = len>>1
     j = len-1
     while length(out) < num
-        isempty(lines[i]) || push!(out, i)
-        isempty(lines[j]) || push!(out, j)
+        is_empty(lines[i]) || push!(out, i)
+        is_empty(lines[j]) || push!(out, j)
         i += 1 > len && break
         j -= 1 < 1   && break
     end
@@ -836,13 +836,13 @@ function comparetestline(lines, results, list, displist)
                 res == funres[j] ||
                     push!(fundiff, typeof(res) == Bool ? (j, text) : (j, text, res, funres[j]))
             end
-            isempty(fundiff) || push!(diff, (i, fun, fundiff))
+            is_empty(fundiff) || push!(diff, (i, fun, fundiff))
         catch ex
             typeof(ex) == InterruptException && rethrow()
             pr"Failed test \(fun): \(sprint(showerror, ex, catch_backtrace()))"
         end
     end
-    if isempty(diff)
+    if is_empty(diff)
         pwc(:green, "\r\u2714\n")
     else
         pwc(:red, "\e[s\rX\e[u")
@@ -874,15 +874,15 @@ function comparetestchar(lines, results, list, displist)
                     res == chrres[k] ||
                         push!(chrdiff, typeof(res) == Bool ? (k, ch) : (k, ch, res, chrres[k]))
                 end
-                isempty(chrdiff) || push!(fundiff, (j, text, chrdiff))
+                is_empty(chrdiff) || push!(fundiff, (j, text, chrdiff))
             end
-            isempty(fundiff) || push!(diff, (i, fun, fundiff))
+            is_empty(fundiff) || push!(diff, (i, fun, fundiff))
         catch ex
             typeof(ex) == InterruptException && rethrow()
             pr"Failed test \(fun): \(sprint(showerror, ex, catch_backtrace()))"
         end
     end
-    if isempty(diff)
+    if is_empty(diff)
         pwc(:green, "\r\u2714\n")
     else
         pwc(:red, "\e[s\rX\e[u")
@@ -914,15 +914,15 @@ function comparetestcu(lines, results, list, displist)
                     res == chrres[k] ||
                         push!(chrdiff, typeof(res) == Bool ? (k, ch) : (k, ch, res, chrres[k]))
                 end
-                isempty(chrdiff) || push!(fundiff, (j, text, chrdiff))
+                is_empty(chrdiff) || push!(fundiff, (j, text, chrdiff))
             end
-            isempty(fundiff) || push!(diff, (i, fun, fundiff))
+            is_empty(fundiff) || push!(diff, (i, fun, fundiff))
         catch ex
             typeof(ex) == InterruptException && rethrow()
             pr"Failed test \(fun): \(sprint(showerror, ex, catch_backtrace()))"
         end
     end
-    if isempty(diff)
+    if is_empty(diff)
         pwc(:green, "\r\u2714\n")
     else
         pwc(:red, "\e[s\rX\e[u")
@@ -940,12 +940,14 @@ function comparetestcu(lines, results, list, displist)
 end
 
 const testlist =
-    (((length, textwidth), "length, textwidth"),
-     ((isascii, isvalid), "isascii, isvalid"),
+    (((length, text_width), "length, text_width"),
+     ((is_ascii, is_valid), "is_ascii, is_valid"),
      ((lowercase, uppercase, reverse), "lowercase, uppercase, reverse"),
-     ((isascii, isvalid, iscntrl, islower, isupper, isalpha,
-       is_alnum, isspace, isprint, ispunct, is_graph, isdigit, isxdigit),
-      "is(ascii|valid|cntrl|lower|upper|alpha|_alnum|space|print|punct|_graph|digit|xdigit)"),
+     ((is_ascii, is_valid, is_control, is_lowercase, is_uppercase, is_alpha,
+       is_alphanumeric, is_space, is_printable, is_punctuation, is_graphic,
+       is_digit, is_hex_digit),
+      "is_(ascii|valid|control|lowercase|uppercase|alpha|alphanumeric|space|printable|" *
+      "punctuation|graphic|digit|hex_digit)"),
      ((UInt32, ), "UInt32"),
      ((sizeof, ), "sizeof"))
 

--- a/test/bounds.jl
+++ b/test/bounds.jl
@@ -1,12 +1,12 @@
 # Test bounds checking
 let b1 = codeunits("abcdef")
-    @test_throws BoundsError checkstring(b1, -10)
-    @test_throws BoundsError checkstring(b1, 0)
-    @test_throws BoundsError checkstring(b1, 7)
-    @test_throws BoundsError checkstring(b1, 3, -10)
-    @test_throws BoundsError checkstring(b1, 3, 0)
-    @test_throws BoundsError checkstring(b1, 3, 7)
-    @test_throws UnicodeError checkstring(b1, 3, 1)
+    @test_throws BoundsError check_string(b1, -10)
+    @test_throws BoundsError check_string(b1, 0)
+    @test_throws BoundsError check_string(b1, 7)
+    @test_throws BoundsError check_string(b1, 3, -10)
+    @test_throws BoundsError check_string(b1, 3, 0)
+    @test_throws BoundsError check_string(b1, 3, 7)
+    @test_throws UnicodeError check_string(b1, 3, 1)
 end
 
 let str = UTF8Str("this is a test\uff")

--- a/test/invalid.jl
+++ b/test/invalid.jl
@@ -2,86 +2,86 @@
 
 # Continuation byte not after lead
 for byt in 0x80:0xbf
-    @test_throws UnicodeError checkstring(UInt8[byt])
+    @test_throws UnicodeError check_string(UInt8[byt])
 end
 
 # Test lead bytes
 for byt in 0xc0:0xff
     # Single lead byte at end of string
-    @test_throws UnicodeError checkstring(UInt8[byt])
+    @test_throws UnicodeError check_string(UInt8[byt])
     # Lead followed by non-continuation character < 0x80
-    @test_throws UnicodeError checkstring(UInt8[byt,0])
+    @test_throws UnicodeError check_string(UInt8[byt,0])
     # Lead followed by non-continuation character > 0xbf
-    @test_throws UnicodeError checkstring(UInt8[byt,0xc0])
+    @test_throws UnicodeError check_string(UInt8[byt,0xc0])
 end
 
 # Test overlong 2-byte
 for byt in 0x81:0xbf
-    @test_throws UnicodeError checkstring(UInt8[0xc0,byt])
+    @test_throws UnicodeError check_string(UInt8[0xc0,byt])
 end
 for byt in 0x80:0xbf
-    @test_throws UnicodeError checkstring(UInt8[0xc1,byt])
+    @test_throws UnicodeError check_string(UInt8[0xc1,byt])
 end
 
 # Test overlong 3-byte
 for byt in 0x80:0x9f
-    @test_throws UnicodeError checkstring(UInt8[0xe0,byt,0x80])
+    @test_throws UnicodeError check_string(UInt8[0xe0,byt,0x80])
 end
 
 # Test overlong 4-byte
 for byt in 0x80:0x8f
-    @test_throws UnicodeError checkstring(UInt8[0xef,byt,0x80,0x80])
+    @test_throws UnicodeError check_string(UInt8[0xef,byt,0x80,0x80])
 end
 
 # Test 4-byte > 0x10ffff
 for byt in 0x90:0xbf
-    @test_throws UnicodeError checkstring(UInt8[0xf4,byt,0x80,0x80])
+    @test_throws UnicodeError check_string(UInt8[0xf4,byt,0x80,0x80])
 end
 for byt in 0xf5:0xf7
-    @test_throws UnicodeError checkstring(UInt8[byt,0x80,0x80,0x80])
+    @test_throws UnicodeError check_string(UInt8[byt,0x80,0x80,0x80])
 end
 
 # Test 5-byte
 for byt in 0xf8:0xfb
-    @test_throws UnicodeError checkstring(UInt8[byt,0x80,0x80,0x80,0x80])
+    @test_throws UnicodeError check_string(UInt8[byt,0x80,0x80,0x80,0x80])
 end
 
 # Test 6-byte
 for byt in 0xfc:0xfd
-    @test_throws UnicodeError checkstring(UInt8[byt,0x80,0x80,0x80,0x80,0x80])
+    @test_throws UnicodeError check_string(UInt8[byt,0x80,0x80,0x80,0x80,0x80])
 end
 
 # Test 7-byte
-@test_throws UnicodeError checkstring(UInt8[0xfe,0x80,0x80,0x80,0x80,0x80,0x80])
+@test_throws UnicodeError check_string(UInt8[0xfe,0x80,0x80,0x80,0x80,0x80,0x80])
 
 # Three and above byte sequences
 for byt in 0xe0:0xef
     # Lead followed by only 1 continuation byte
-    @test_throws UnicodeError checkstring(UInt8[byt,0x80])
+    @test_throws UnicodeError check_string(UInt8[byt,0x80])
     # Lead ended by non-continuation character < 0x80
-    @test_throws UnicodeError checkstring(UInt8[byt,0x80,0])
+    @test_throws UnicodeError check_string(UInt8[byt,0x80,0])
     # Lead ended by non-continuation character > 0xbf
-    @test_throws UnicodeError checkstring(UInt8[byt,0x80,0xc0])
+    @test_throws UnicodeError check_string(UInt8[byt,0x80,0xc0])
 end
 
 # 3-byte encoded surrogate character(s)
 # Single surrogate
-@test_throws UnicodeError checkstring(UInt8[0xed,0xa0,0x80])
+@test_throws UnicodeError check_string(UInt8[0xed,0xa0,0x80])
 # Not followed by surrogate
-@test_throws UnicodeError checkstring(UInt8[0xed,0xa0,0x80,0xed,0x80,0x80])
+@test_throws UnicodeError check_string(UInt8[0xed,0xa0,0x80,0xed,0x80,0x80])
 # Trailing surrogate first
-@test_throws UnicodeError checkstring(UInt8[0xed,0xb0,0x80,0xed,0xb0,0x80])
+@test_throws UnicodeError check_string(UInt8[0xed,0xb0,0x80,0xed,0xb0,0x80])
 # Followed by lead surrogate
-@test_throws UnicodeError checkstring(UInt8[0xed,0xa0,0x80,0xed,0xa0,0x80])
+@test_throws UnicodeError check_string(UInt8[0xed,0xa0,0x80,0xed,0xa0,0x80])
 
 # Four byte sequences
 for byt in 0xf0:0xf4
     # Lead followed by only 2 continuation bytes
-    @test_throws UnicodeError checkstring(UInt8[byt,0x80,0x80])
+    @test_throws UnicodeError check_string(UInt8[byt,0x80,0x80])
     # Lead followed by non-continuation character < 0x80
-    @test_throws UnicodeError checkstring(UInt8[byt,0x80,0x80,0])
+    @test_throws UnicodeError check_string(UInt8[byt,0x80,0x80,0])
     # Lead followed by non-continuation character > 0xbf
-    @test_throws UnicodeError checkstring(UInt8[byt,0x80,0x80,0xc0])
+    @test_throws UnicodeError check_string(UInt8[byt,0x80,0x80,0xc0])
 end
 
 # Long encoding of 0x01
@@ -90,22 +90,22 @@ end
 # Test ends of long encoded surrogates
 @test_throws UnicodeError utf8([0xf0, 0x8d, 0xa0, 0x80])
 @test_throws UnicodeError utf8([0xf0, 0x8d, 0xbf, 0xbf])
-@test_throws UnicodeError checkstring([0xf0, 0x80, 0x80, 0x80])
-@test checkstring([0xc0, 0x81]; accept_long_char=true) == (1,0x1,0,0,0,0,0)
-@test checkstring([0xf0, 0x80, 0x80, 0x80]; accept_long_char=true) == (1,0x1,0,0,0,0,0)
+@test_throws UnicodeError check_string([0xf0, 0x80, 0x80, 0x80])
+@test check_string([0xc0, 0x81]; accept_long_char=true) == (1,0x1,0,0,0,0,0)
+@test check_string([0xf0, 0x80, 0x80, 0x80]; accept_long_char=true) == (1,0x1,0,0,0,0,0)
 
 # Surrogates
-@test_throws UnicodeError checkstring(UInt16[0xd800])
-@test_throws UnicodeError checkstring(UInt16[0xdc00])
-@test_throws UnicodeError checkstring(UInt16[0xdc00,0xd800])
+@test_throws UnicodeError check_string(UInt16[0xd800])
+@test_throws UnicodeError check_string(UInt16[0xdc00])
+@test_throws UnicodeError check_string(UInt16[0xdc00,0xd800])
 
 # Surrogates in UTF-32
-@test_throws UnicodeError checkstring(UInt32[0xd800])
-@test_throws UnicodeError checkstring(UInt32[0xdc00])
-@test_throws UnicodeError checkstring(UInt32[0xdc00,0xd800])
+@test_throws UnicodeError check_string(UInt32[0xd800])
+@test_throws UnicodeError check_string(UInt32[0xdc00])
+@test_throws UnicodeError check_string(UInt32[0xdc00,0xd800])
 
 # Characters > 0x10ffff
-@test_throws UnicodeError checkstring(UInt32[0x110000])
+@test_throws UnicodeError check_string(UInt32[0x110000])
 
 # Test more invalid (overlong) sequences
 for (seq, res) in (
@@ -114,8 +114,8 @@ for (seq, res) in (
     ([0xed,0xaf,0xbf,0xed,0xbf,0xbf], (1,0x30,1,0,0,0,0)), # Overlong \U10ffff, (CESU-8)
     ([0x0d800,0x0dc00],    (1,0x30,1,0,0,0,0)), # Overlong \U10000, (CESU-8)
     ([0x0dbff,0x0dfff],    (1,0x30,1,0,0,0,0))) # Overlong \U10ffff, (CESU-8)
-    @test_throws UnicodeError checkstring(seq)
-    @test checkstring(seq;accept_long_null=true, accept_surrogates=true, accept_long_char=true) == res
+    @test_throws UnicodeError check_string(seq)
+    @test check_string(seq;accept_long_null=true, accept_surrogates=true, accept_long_char=true) == res
 end
 
 # Test conversions of invalid sequences

--- a/test/regex.jl
+++ b/test/regex.jl
@@ -14,39 +14,40 @@ end
 
 @testset "Regex" begin
     for T in RegexStrings
-@test collect_eachmatch(r"a?b?", T("asbd")) == ["a","","b","",""] ==
-    collect_eachmatch(r"""a?b?""", T("asbd"))
-@test collect_eachmatch(r"a?b?", T("asbd"), overlap=true) == ["a","","b","",""]
-@test collect_eachmatch(r"\w+", T("hello"), overlap=true) == ["hello","ello","llo","lo","o"]
-@test collect_eachmatch(r"(\w+)(\s*)", T("The dark side of the moon")) ==
-    ["The ", "dark ", "side ", "of ", "the ", "moon"]
-@test collect_eachmatch(r"", T("")) == [""]
-@test collect_eachmatch(r"", T(""), overlap=true) == [""]
-@test collect_eachmatch(r"aa", T("aaaa")) == ["aa", "aa"]
-@test collect_eachmatch(r"aa", T("aaaa"), overlap=true) == ["aa", "aa", "aa"]
-@test collect_eachmatch(r"", T("aaa")) == ["", "", "", ""]
-@test collect_eachmatch(r"", T("aaa"), overlap=true) == ["", "", "", ""]
-@test collect_eachmatch(r"GCG", T("GCGCG")) == ["GCG"]
-@test collect_eachmatch(r"GCG", T("GCGCG"),overlap=true) == ["GCG","GCG"]
+        @test collect_eachmatch(r"a?b?", T("asbd")) == ["a","","b","",""] ==
+            collect_eachmatch(r"""a?b?""", T("asbd"))
+        @test collect_eachmatch(r"a?b?", T("asbd"), overlap=true) == ["a","","b","",""]
+        @test collect_eachmatch(r"\w+", T("hello"), overlap=true) ==
+            ["hello","ello","llo","lo","o"]
+        @test collect_eachmatch(r"(\w+)(\s*)", T("The dark side of the moon")) ==
+            ["The ", "dark ", "side ", "of ", "the ", "moon"]
+        @test collect_eachmatch(r"", T("")) == [""]
+        @test collect_eachmatch(r"", T(""), overlap=true) == [""]
+        @test collect_eachmatch(r"aa", T("aaaa")) == ["aa", "aa"]
+        @test collect_eachmatch(r"aa", T("aaaa"), overlap=true) == ["aa", "aa", "aa"]
+        @test collect_eachmatch(r"", T("aaa")) == ["", "", "", ""]
+        @test collect_eachmatch(r"", T("aaa"), overlap=true) == ["", "", "", ""]
+        @test collect_eachmatch(r"GCG", T("GCGCG")) == ["GCG"]
+        @test collect_eachmatch(r"GCG", T("GCGCG"),overlap=true) == ["GCG","GCG"]
 
 # Issue 8278
 target = """71.163.72.113 - - [30/Jul/2014:16:40:55 -0700] "GET emptymind.org/thevacantwall/wp-content/uploads/2013/02/DSC_006421.jpg HTTP/1.1" 200 492513 "http://images.search.yahoo.com/images/view;_ylt=AwrB8py9gdlTGEwADcSjzbkF;_ylu=X3oDMTI2cGZrZTA5BHNlYwNmcC1leHAEc2xrA2V4cARvaWQDNTA3NTRiMzYzY2E5OTEwNjBiMjc2YWJhMjkxMTEzY2MEZ3BvcwM0BGl0A2Jpbmc-?back=http%3A%2F%2Fus.yhs4.search.yahoo.com%2Fyhs%2Fsearch%3Fei%3DUTF-8%26p%3Dapartheid%2Bwall%2Bin%2Bpalestine%26type%3Dgrvydef%26param1%3D1%26param2%3Dsid%253Db01676f9c26355f014f8a9db87545d61%2526b%253DChrome%2526ip%253D71.163.72.113%2526p%253Dgroovorio%2526x%253DAC811262A746D3CD%2526dt%253DS940%2526f%253D7%2526a%253Dgrv_tuto1_14_30%26hsimp%3Dyhs-fullyhosted_003%26hspart%3Dironsource&w=588&h=387&imgurl=occupiedpalestine.files.wordpress.com%2F2012%2F08%2F5-peeking-through-the-wall.jpg%3Fw%3D588%26h%3D387&rurl=http%3A%2F%2Fwww.stopdebezetting.com%2Fwereldpers%2Fcompare-the-berlin-wall-vs-israel-s-apartheid-wall-in-palestine.html&size=49.0KB&name=...+%3Cb%3EApartheid+wall+in+Palestine%3C%2Fb%3E...+%7C+Or+you+go+peeking+through+the+%3Cb%3Ewall%3C%2Fb%3E&p=apartheid+wall+in+palestine&oid=50754b363ca991060b276aba291113cc&fr2=&fr=&tt=...+%3Cb%3EApartheid+wall+in+Palestine%3C%2Fb%3E...+%7C+Or+you+go+peeking+through+the+%3Cb%3Ewall%3C%2Fb%3E&b=0&ni=21&no=4&ts=&tab=organic&sigr=13evdtqdq&sigb=19k7nsjvb&sigi=12o2la1db&sigt=12lia2m0j&sign=12lia2m0j&.crumb=.yUtKgFI6DE&hsimp=yhs-fullyhosted_003&hspart=ironsource" "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/36.0.1985.125 Safari/537.36"""
 
-pat = r"""([\d\.]+) ([\w.-]+) ([\w.-]+) (\[.+\]) "([^"\r\n]*|[^"\r\n\[]*\[.+\][^"]+|[^"\r\n]+.[^"]+)" (\d{3}) (\d+|-) ("(?:[^"]|\")+)"? ("(?:[^"]|\")+)"?"""
+        pat = r"""([\d\.]+) ([\w.-]+) ([\w.-]+) (\[.+\]) "([^"\r\n]*|[^"\r\n\[]*\[.+\][^"]+|[^"\r\n]+.[^"]+)" (\d{3}) (\d+|-) ("(?:[^"]|\")+)"? ("(?:[^"]|\")+)"?"""
 
-match(pat, T(target))
+        match(pat, T(target))
 
-# Issue 9545 (32 bit)
-buf = PipeBuffer()
-show(buf, r"")
-@test read(buf, String) == "r\"\""
+        # Issue 9545 (32 bit)
+        buf = PipeBuffer()
+        show(buf, r"")
+        @test read(buf, String) == "r\"\""
 
-# see #10994, #11447: PCRE2 allows NUL chars in the pattern
-@test contains(T("a\0b"), Regex(T("^a\0b\$")))
+        # see #10994, #11447: PCRE2 allows NUL chars in the pattern
+        @test contains(T("a\0b"), Regex(T("^a\0b\$")))
 
-# regex match / search string must be a String
-@test_throws ArgumentError match(r"test", GenericString("this is a test"))
-@test_throws ArgumentError findfirst(r"test", GenericString("this is a test"))
+        # regex match / search string must be a String
+        @test_throws ArgumentError match(r"test", GenericString("this is a test"))
+        @test_throws ArgumentError fnd(Fwd, r"test", GenericString("this is a test"))
 
 # Named subpatterns
 let m = match(r"(?<a>.)(.)(?<b>.)", T("xyz"))

--- a/test/regex.jl
+++ b/test/regex.jl
@@ -49,14 +49,14 @@ target = """71.163.72.113 - - [30/Jul/2014:16:40:55 -0700] "GET emptymind.org/th
         @test_throws ArgumentError match(r"test", GenericString("this is a test"))
         @test_throws ArgumentError fnd(Fwd, r"test", GenericString("this is a test"))
 
-# Named subpatterns
-let m = match(r"(?<a>.)(.)(?<b>.)", T("xyz"))
-    @test (m[:a], m[2], m["b"]) == ("x", "y", "z")
-    @test sprint(show, m) == "RegexMatchStr(\"xyz\", a=\"x\", 2=\"y\", b=\"z\")"
-end
+        # Named subpatterns
+        let m = match(r"(?<a>.)(.)(?<b>.)", T("xyz"))
+            @test (m[:a], m[2], m["b"]) == ("x", "y", "z")
+            @test sprint(show, m) == "RegexMatchStr(\"xyz\", a=\"x\", 2=\"y\", b=\"z\")"
+        end
 
-# Backcapture reference in substitution string
-@test replace(T("abcde"), r"(..)(?P<byname>d)" => s"\g<byname>xy\\\1") == "adxy\\bce"
+        # Backcapture reference in substitution string
+        @test replace(T("abcde"), r"(..)(?P<byname>d)" => s"\g<byname>xy\\\1") == "adxy\\bce"
         @test_throws ErrorException replace("a", r"(?P<x>)" => s"\g<y>")
 end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,7 +4,7 @@
 @static VERSION < v"0.7.0-DEV" ? (using Base.Test) : (using Test)
 
 using Strs
-import Strs: checkstring, UTF_ERR_SHORT, UnicodeError, codepoint_adj, codepoint_rng
+import Strs: check_string, UTF_ERR_SHORT, UnicodeError, codepoint_adj, codepoint_rng
 
 # Function to help generating strings for tests
 randchar(::Type{T}) where {T} = codepoint_adj(T, rand(codepoint_rng(T)))

--- a/test/search.jl
+++ b/test/search.jl
@@ -6,16 +6,18 @@ const astr = "Hello, world.\n"
 const u8str = "∀ ε > 0, ∃ δ > 0: |x-y| < δ ⇒ |f(x)-f(y)| < ε"
 const fbbstr = "foo,bar,baz"
 
+const u8map = [1, 4, 5, 7, 8, 9, 10, 11, 12, 13, 16, 17, 19, 20, 21, 22, 23, 24,
+               25, 26, 27, 28, 29, 30, 31, 32, 33, 35, 36, 39, 40, 41, 42, 43, 44,
+               45, 46, 47, 48, 49, 50, 51, 52, 53, 54]
+
 # Should test GenericString also, once overthing else is working
 const UnicodeStringTypes =
-    (String, UTF16Str, UTF32Str, UniStr, UTF8Str)
+    # (String, UTF16Str, UTF32Str, UniStr, UTF8Str)
+    # (String, UTF8Str)
+    (UTF8Str, )
 const ASCIIStringTypes =
     (String, UTF8Str, ASCIIStr, LatinStr)
     #    (UnicodeStringTypes..., ASCIIStr, LatinStr, UCS2Str)
-
-const ustr = (("éé", "ééé"), ("€€", "€€€"), ("\U1f596\U1f596", "\U1f596\U1f596\U1f596"))
-const resfirst = (1:3, 1:4, 1:5)
-const reslast  = (3:5, 4:7, 5:9)
 
 function cvtchar(T, ch)
     try 
@@ -25,45 +27,45 @@ function cvtchar(T, ch)
     end
 end
 
-function test2(fun, P, str, list)
-    for (pat, res) in list
-        p = P(pat)
-        (r = fun(pat, str)) == res ||
-            println("$(fun)($(typeof(pat)):\"$pat\", $(typeof(str)):\"$str\") => $r != $res")
-        @test fun(pat, str) == res
+function test2(dir, P, str, list)
+    for (p, res) in list
+        pat = typeof(p) == Regex ? p : P(p)
+        (r = fnd(dir, pat, str)) == res ||
+            println("fnd($dir, $(typeof(pat)):\"$pat\", $(typeof(str)):\"$str\") => $r != $res")
+        @test fnd(dir, pat, str) == res
     end
 end
 
-function test3(fun, P, str, list)
-    for (pat, beg, res) in list
-        p = P(pat)
-        (r = fun(pat, str, beg)) == res ||
-            println("$(fun)($(typeof(pat)):\"$pat\", $(typeof(str)):\"$str\", $beg) => $r != $res")
-        @test fun(pat, str, beg) == res
+function test3(dir, P, str, list)
+    for (p, beg, res) in list
+        pat = typeof(p) == Regex ? p : P(p)
+        (r = fnd(dir, pat, str, beg)) == res ||
+            println("fnd($dir, $(typeof(pat)):\"$pat\", $(typeof(str)):\"$str\", $beg) => $r != $res")
+        @test fnd(dir, pat, str, beg) == res
     end
 end
 
-function test2ch(fun, C, str, list)
+function test2ch(dir, C, str, list)
     for (p, res) in list
         pat = cvtchar(C, p)
-        (r = fun(pat, str)) == res ||
-            println("$(fun)($(typeof(pat)):\"$pat\"), $(typeof(str)):\"$str\") => $r != $res")
-        (r = fun(equalto(pat), str)) == res ||
-            println("$(fun)(equalto($(typeof(pat)):\"$pat\"), $(typeof(str)):\"$str\") => $r != $res")
-        @test fun(pat, str) == res
-        @test fun(equalto(pat), str) == res
+        (r = fnd(dir, pat, str)) == res ||
+            println("fnd($dir, $(typeof(p)):\"$pat\"), $(typeof(str)):\"$str\") => $r != $res")
+        (r = fnd(dir, equalto(pat), str)) == res ||
+            println("fnd($dir, equalto($(typeof(pat)):\"$pat\"), $(typeof(str)):\"$str\") => $r != $res")
+        @test fnd(dir, pat, str) == res
+        @test fnd(dir, equalto(pat), str) == res
     end
 end
 
-function test3ch(fun, C, str, list)
+function test3ch(dir, C, str, list)
     for (p, beg, res) in list
         pat = cvtchar(C, p)
-        (r = fun(pat, str, beg)) == res ||
-            println("$(fun)($(typeof(pat)):'$pat', $(typeof(str)):\"$str\", $beg) => $r != $res")
-        (r = fun(equalto(pat), str, beg)) == res ||
-            println("$fun(equalto($(typeof(pat)):'$pat'), $(typeof(str)):\"$str\", $beg) => $r != $res")
-        @test fun(pat, str, beg) == res
-        @test fun(equalto(pat), str, beg) == res
+        (r = fnd(dir, pat, str, beg)) == res ||
+            println("fnd($dir, $(typeof(pat)):'$pat', $(typeof(str)):\"$str\", $beg) => $r != $res")
+        (r = fnd(dir, equalto(pat), str, beg)) == res ||
+            println("fnd($dir, equalto($(typeof(pat)):'$pat'), $(typeof(str)):\"$str\", $beg) => $r != $res")
+        @test fnd(dir, pat, str, beg) == res
+        @test fnd(dir, equalto(pat), str, beg) == res
     end
 end
 
@@ -71,282 +73,242 @@ end
     for T in ASCIIStringTypes, P in ASCIIStringTypes
         @testset "pattern: $P, str: $T" begin
             str = T(astr)
+            fbb = T(fbbstr)
             C = eltype(P)
             lst = nextind(str, lastindex(str))
             empty_pred = occursin(C[])
             @testset "BoundsError" begin
-                for ind in (0, lst, lst+1), fun in (find_next, find_prev)
-                    @test_throws BoundsError fun(SubString(P(""),1,1), str, ind)
-                    @test_throws BoundsError fun(equalto(cvtchar(C,'a')), str, ind)
-                    @test_throws BoundsError fun(equalto(cvtchar(C,'∀')), str, ind)
-                    @test_throws BoundsError fun(equalto(cvtchar(C,'ε')), str, ind)
-                    @test_throws BoundsError fun(empty_pred, str, ind)
+                for ind in (0, lst, lst+1), dir in (Fwd, Rev)
+                    @test_throws BoundsError fnd(dir, SubString(P(""),1,1), str, ind)
+                    @test_throws BoundsError fnd(dir, equalto(cvtchar(C,'a')), str, ind)
+                    @test_throws BoundsError fnd(dir, equalto(cvtchar(C,'∀')), str, ind)
+                    @test_throws BoundsError fnd(dir, equalto(cvtchar(C,'ε')), str, ind)
+                    @test_throws BoundsError fnd(dir, empty_pred, str, ind)
                 end
             end
-            @testset "find_*(equalto(ch)...)" begin
+            @testset "fnd(dir, equalto(ch)...)" begin
                 let pats = ('x', '\0', '\u80', '∀', 'H', 'l', ',', '\n'),
                     res  = (0,   0,    0,      0,   1,   3,   6,   14)
-                    test2ch(find_first, C, str, zip(pats, res))
+                    test2ch(Fwd, C, str, zip(pats, res))
                 end
                 let pats = ('l', 'l', 'l', ',', '.'),
                     pos  = (  4,   5,  12,  7,   14),
                     res  = (  4,  11,   0,  0,    0)
-                    test3ch(find_next,  C, str, zip(pats, pos, res))
+                    test3ch(Fwd,  C, str, zip(pats, pos, res))
                 end
                 let pats = ('x', '\0', '\u80', '∀', 'H', 'l', ',', '\n'),
                     res  = (0, 0, 0, 0, 1, 11, 6, 14)
-                    test2ch(find_last,  C, str, zip(pats, res))
+                    test2ch(Rev,  C, str, zip(pats, res))
                 end
                 let pats = ('H', 'l', 'l', 'l', 'l', ','),
                     pos  = (1, 5, 4, 3, 2, 5),
                     res  = (1, 4, 4, 3, 0, 0)
-                    test3ch(find_prev,  C, str, zip(pats, pos, res))
+                    test3ch(Rev,  C, str, zip(pats, pos, res))
                 end
             end
-            @testset "find_* single-char string" begin
-                test2(find_first, P, str,
+            @testset "find single-char string" begin
+                test2(Fwd, P, str,
                       (("x", 0:-1), ("H", 1:1), ("l", 3:3), ("\n", 14:14)))
-                test2(find_last,  P, str,
+                test2(Rev,  P, str,
                       (("x", 0:-1), ("H", 1:1), ("l", 11:11), ("\n", 14:14)))
-                test3(find_next,  P, str,
+                test3(Fwd,  P, str,
                       (("H", 2, 0:-1), ("l", 4, 4:4), ("l", 5, 11:11),
                        ("l", 12, 0:-1), (".", 14, 0:-1), ("\n", 14, 14:14)))
-                test3(find_prev,  P, str,
+                test3(Rev,  P, str,
                       (("H", 2, 1:1), ("H", 1, 1:1), ("l", 10, 4:4),
                        ("l", 4, 4:4), ("l", 3, 3:3), ("l", 2, 0:-1), ("\n", 13, 0:-1)))
             end
 
-            str = T(fbbstr)
-            @testset "find_* two-char string" begin
+            @testset "find two-char string" begin
                 let pats = ("xx", "fo", "oo", "o,", ",b", "az"),
                     res  = (0:-1, 1:2,  2:3,  3:4,  4:5,  10:11)
-                    test2(find_first, P, str, zip(pats, res))
+                    test2(Fwd, P, fbb, zip(pats, res))
                 end
                 let pats = ("fo", "oo", "o,", ",b", ",b", "az"),
                     pos  = (3,    4,    5,    6,    10,   11), # was 12, that gives boundserror
                     res  = (0:-1, 0:-1, 0:-1, 8:9,  0:-1, 0:-1)
-                    test3(find_next, P, str, zip(pats, pos, res))
+                    test3(Fwd, P, fbb, zip(pats, pos, res))
                 end
                 # string backward search with a two-char string literal
                 let pats = ("xx", "fo", "oo", "o,", ",b", "az"),
                     res  = (0:-1, 1:2,  2:3,  3:4,  8:9,  10:11)
-                    test2(find_last, P, str, zip(pats, res))
+                    test2(Rev, P, fbb, zip(pats, res))
                 end
                 let pats = ("fo", "oo", "o,", ",b", ",b", "az"),
                     pos  = (1,    2,    1,    6,    3,    10),
                     res  = (0:-1, 0:-1, 0:-1, 4:5,  0:-1, 0:-1)
-                    test3(find_prev, P, str, zip(pats, pos, res))
+                    test3(Rev, P, fbb, zip(pats, pos, res))
                 end
             end
 
             emptyT = T("")
             emptyP = P("")
 
-            @testset "find_* empty string,..." begin
-                for i = 1:lastindex(str)
-                    @test find_next(emptyP, str, i) == i:i-1
-                end
-                for i = 1:lastindex(str)
-                    @test find_prev(emptyP, str, i) == i:i-1
+            @testset "find empty string,..." begin
+                i = 1
+                while i <= ncodeunits(str)
+                    @test fnd(Fwd, emptyP, str, i) == i:i-1
+                    @test fnd(Rev, emptyP, str, i) == i:i-1
+                    i = nextind(str, i)
                 end
             end
 
-            @test find_first(emptyP, emptyT) == 1:0
-            @test find_last(emptyP, emptyT) == 1:0
+            @test fnd(Fwd, emptyP, emptyT) == 1:0
+            @test fnd(Rev, emptyP, emptyT) == 1:0
+
+            @testset "Regex" begin
+                # string forward search with a single-char regex
+                let pats = (r"x", r"H", r"l", r"\n"),
+                    res  = (0:-1, 1:1, 3:3, 14:14)
+                    test2(Fwd, P, str, zip(pats, res))
+                end
+                let pats = (r"H", r"l", r"l", r"l", r"\n"),
+                    pos  = (  2,    4,    5,   12,    14), # Was 15 for findnext
+                    res  = (0:-1, 4:4,11:11, 0:-1, 14:14)
+                    test3(Fwd, P, str, zip(pats, pos, res))
+                end
+                i = 1
+                while i <= ncodeunits(str)
+                    @test fnd(Fwd, r"."s, str, i) == i:i
+                    # string forward search with a zero-char regex
+                    @test fnd(Fwd, r"", str, i) == i:i-1
+                    i = nextind(str, i)
+                end
+                let pats = (r"xx", r"fo", r"oo", r"o,", r",b", r"az"),
+                    res  = ( 0:-1,   1:2,   2:3,   3:4,   4:5, 10:11)
+                    test2(Fwd, P, fbb, zip(pats, res))
+                end
+                let pats = (r"fo", r"oo", r"o,", r",b", r",b", r"az"),
+                    pos  = (    3,     4,     5,     6,    10,    11),
+                    res  = ( 0:-1,  0:-1,  0:-1,   8:9,  0:-1,  0:-1) # was 12 for findnext
+                    test3(Fwd, P, fbb, zip(pats, pos, res))
+                end
+            end
         end
     end
 end
 
-#=
 @testset "Unicode Tests" begin
-    @testset for T in UnicodeStringTypes
-        str = T(u8str)
-        lst = nextind(str, lastindex(str))
-        @testset "find_*(equalto(chr),..." begin
+    for T in UnicodeStringTypes, P in UnicodeStringTypes
+        @testset "pattern: $P, str: $T" begin
+            str = T(u8str)
+            lst = nextind(str, lastindex(str))
+            C = eltype(P)
             @testset "BoundsError" begin
-                @test_throws BoundsError find_next('z', str, 0)
-                @test_throws BoundsError find_next('∀', str, 0)
-                @test_throws BoundsError find_next('ε', str, lst+1)
-                @test_throws BoundsError find_next('a', str, lst+1)
+                for ch = ('z', '∀', 'ε', 'a'), ind = (0, lst, lst+1)
+                    @test_throws BoundsError fnd(Fwd, cvtchar(C, ch), str, ind)
+                end
             end
             @testset "Index Error" begin
-                @test_throws StringIndexError find_next('∀', str, 2)
-                @test_throws StringIndexError find_next('∃', str, 15)
-                @test_throws StringIndexError find_next('δ', str, 18)
+                @test_throws StringIndexError fnd(Fwd, cvtchar(C, '∀'), str, 2)
+                @test_throws StringIndexError fnd(Fwd, cvtchar(C, '∃'), str, 15)
+                @test_throws StringIndexError fnd(Fwd, cvtchar(C, 'δ'), str, 18)
             end
-            test2ch(find_first, T, str, u8str,
-                    (('z', 0), ('\0', 0), ('\u80', 0), ('∄', 0), ('∀', 1),
-                     ('∃', 13), ('x', 26), ('δ', 17), ('ε', 5)))
-            test3ch(find_next, T, str, u8str,
-                    (('∀', 4, 0), ('∃', 16, 0), ('x', 27, 43), ('x', 44, 0)))
+            @testset "fnd(Fwd, equalto(chr),..." begin
+                test2ch(Fwd, C, str,
+                        (('z', 0), ('\0', 0), ('\u80', 0), ('∄', 0), ('∀', 1),
+                         ('∃', 13), ('x', 26), ('δ', 17), ('ε', 5)))
+                test3ch(Fwd, C, str,
+                        (('∀', 4, 0), ('∃', 16, 0), ('x', 27, 43), ('x', 44, 0)))
 
-            @test find_next('δ', str, nextind(str, 17)) == 33
-            @test find_next('δ', str, nextind(str, 33)) == 0
-            @test find_next('ε', str, nextind(str,  5)) == 54
-            @test find_next('ε', str, nextind(str, 54)) == 0
-            for ch in ('ε', 'a')
-                @test find_next(equalto(ch), str, lst) == 0
+                @test fnd(Fwd, cvtchar(C, 'δ'), str, nextind(str, 17)) == 33
+                @test fnd(Fwd, cvtchar(C, 'δ'), str, nextind(str, 33)) == 0
+                @test fnd(Fwd, cvtchar(C, 'ε'), str, nextind(str,  5)) == 54
+                # These give BoundsError now
+                #@test fnd(Fwd, 'ε', str, nextind(str, 54)) == 0
+                #for ch in ('ε', 'a')
+                #   @test fnd(Fwd, equalto(ch), str, lst) == 0
+                #end
             end
 
-            test2ch(find_last, T, str, u8str,
-                    zip(('z', '\0', '\u80', '∄', '∀', '∃', 'x', 'δ', 'ε'),
-                        (0, 0, 0, 0, 1, 13, 43, 33, 54)))
-            test3ch(find_prev, T, str, u8str,
-                    zip(('∀', '∃', '∃', '∃', 'x', 'x', 'δ', 'δ', 'ε', 'ε'),
-                        (0, 14, 13, 12, 42, 25, 32, 16, 53, 4),
-                        (0, 13, 13,  0, 26,  0, 17,  0,  5, 0)))
-        end
-
-        @testset "find_* 1-char string,..." begin
-            @test find_first("z", str) == 0:-1
-            @test find_first("∄", str) == 0:-1
-            @test find_first("∀", str) == 1:1
-            @test find_first("∃", str) == 13:13
-            @test find_first("x", str) == 26:26
-            @test find_first("ε", str) == 5:5
-
-            @test find_next("∀", str, 4) == 0:-1
-            @test find_next("∃", str, 16) == 0:-1
-            @test find_next("x", str, 27) == 43:43
-            @test find_next("x", str, 44) == 0:-1
-            @test find_next("ε", str, 7) == 54:54
-            @test find_next("ε", str, 56) == 0:-1
-
-            @test find_last("z", str) == 0:-1
-            @test find_last("∄", str) == 0:-1
-            @test find_last("∀", str) == 1:1
-            @test find_last("∃", str) == 13:13
-            @test find_last("x", str) == 43:43
-            @test find_last("ε", str) == 54:54
-
-            @test find_prev("∀", str, 0) == 0:-1
-            #TODO: setting the limit in the middle of a wide char
-            #      makes find_next fail but find_prev succeed.
-            #      Should find_prev fail as well?
-            #@test find_prev("∀", str, 2) == 0:-1 # gives 1:3
-            @test find_prev("∃", str, 12) == 0:-1
-            @test find_prev("x", str, 42) == 26:26
-            @test find_prev("x", str, 25) == 0:-1
-            @test find_prev("ε", str, 53) == 5:5
-            @test find_prev("ε", str, 4) == 0:-1
-        end
-
-        empty = T("")
-        @testset "find_* empty string,..." begin
-            for i = 1:lastindex(str)
-                @test find_next(empty, str, i) == i:i-1
+            @testset "fnd(Rev, equalto(chr),..." begin
+                test2ch(Rev, C, str,
+                        zip(('z', '\0', '\u80', '∄', '∀', '∃', 'x', 'δ', 'ε'),
+                            (  0,    0,      0,   0,   1,  13,  43,  33,  54)))
+                test3ch(Rev, C, str,
+                        zip(('∀', '∃', '∃', '∃', 'x', 'x', 'δ', 'δ', 'ε', 'ε'),
+                            (1, 16, 13, 12, 42, 25, 32, 16, 53, 4), # first entry was 0, second 14
+                            (1, 13, 13,  0, 26,  0, 17,  0,  5, 0))) # first entry was 0 -> 1
             end
-            for i = 1:lastindex(str)
-                @test find_prev(empty, str, i) == i:i-1
-            end
-        end
 
-        # Convert to new type
-        cvtstr = ((T(s[1]),T(s[2])) for s in ustr)
-        # issue #9365
-        @testset "issue #9365" begin
-            for (cvt, resf, resl) in zip(cvtstr, resfirst, reslast)
-                a, b = cvt
-                @test find_first(a, b) == resf
-                @test find_next(a, b, 1) == resf
-                @test find_first(a, a) == resf
-                @test find_next(a, a, 1) == resf
-                @test find_last(a, b) == resl
-                @test find_prev(a, b, lastindex(b)) == resl
-                @test find_last(a, a) == resf
-                @test find_prev(a, a, lastindex(a)) == resf
+            @testset "find 1-char string,..." begin
+                let pat = ( "z",  "∄", "∀",   "∃",   "x",   "ε"),
+                    fwd = (0:-1, 0:-1, 1:1, 13:13, 26:26,   5:5),
+                    rev = (0:-1, 0:-1, 1:1, 13:13, 43:43, 54:54)
+
+                    test2(Fwd, P, str, zip(pat, fwd))
+                    test2(Rev, P, str, zip(pat, rev))
+                end
+                let pat  = ( "∀",  "∃", "x",   "x",   "ε",   "ε"),
+                    posf = (   4,   16,  27,    44,     7,    54),  # was 56 for findnext
+                    resf = (0:-1, 0:-1,43:43, 0:-1, 54:54, 54:54),
+                    posr = (   1,   12,  42,    25,    53,     4),
+                    resr = ( 1:1, 0:-1,26:26, 0:-1,   5:5,  0:-1)
+
+                    test3(Fwd, P, str, zip(pat, posf, resf))
+                    test3(Rev, P, str, zip(pat, posr, resr))
+                end
+            end
+
+            empty = T("")
+            @testset "find empty string,..." begin
+                i = 1
+                while i <= ncodeunits(str)
+                    @test fnd(Fwd, empty, str, i) == i:i-1
+                    @test fnd(Rev, empty, str, i) == i:i-1
+                    i = nextind(str, i)
+                end
+            end
+
+            # issue #9365
+            @testset "issue #9365" begin
+                let ustr = (("éé", "ééé"),
+                            ("€€", "€€€"),
+                            ("\U1f596\U1f596", "\U1f596\U1f596\U1f596")),
+                    fwd = (1:3, 1:4, 1:5),
+                    rev = (3:5, 4:7, 5:9)
+                    for (s, resf, resl) in zip(ustr, fwd, rev)
+                        a = P(first(s))
+                        b = T(last(s))
+                        @test fnd(Fwd, a, b) == resf
+                        @test fnd(Fwd, a, a) == resf
+                        @test fnd(Rev, a, b) == resl
+                        @test fnd(Rev, a, a) == resf
+                    end
+                end
+            end
+            @testset "Regex" begin
+                let pats = (r"z", r"∄", r"∀", r"∃", r"x", r"ε"),
+                    res  = (0:-1, 0:-1, 1:1, 13:13,26:26,  5:5)
+                    test2(Fwd, P, str, zip(pats, res))
+                end
+                let pats = (r"∀", r"∃", r"x", r"x", r"ε", r"ε"),
+                    pos  = (   4,   16,   27,   44,    7,   54), # was 56 for findnext
+                    res  = (0:-1, 0:-1,43:43, 0:-1,54:54,54:54)  # was 0:-1 for last
+                    test3(Fwd, P, str, zip(pats, pos, res))
+                end
+                @test fnd(Fwd, r"∀", str)    == fnd(Fwd, r"\u2200", str)
+                @test fnd(Fwd, r"∀", str, 4) == fnd(Fwd, r"\u2200", str, 4)
+                i = 1
+                while i <= ncodeunits(str)
+                    @test fnd(Fwd, r"."s, str, i) == i:i
+                    # string forward search with a zero-char regex
+                    @test fnd(Fwd, r"", str, i) == i:i-1
+                    i = nextind(str, i)
+                end
+            end
+            @testset "issue #15723" begin
+                str = T("(⨳(")
+                test2ch(Fwd, C, T("⨳("), zip(('(',), (4,)))
+                test2ch(Rev, C, str, zip(('(',), (5,)))
+                test3ch(Fwd, C, str, zip(('(',), (2,), (5,)))
+                test3ch(Rev, C, str, zip(('(',), (2,), (1,)))
+            end
+            @testset "contains with a String and Char needle" begin
+                str = T("foo")
+                @test contains(str, P("o"))
+                @test contains(str, cvtchar(C, 'o'))
             end
         end
     end
 end
-=#
-
-@testset "ASCII Regex" begin
-    # string forward search with a single-char regex
-    @test find_first(r"x", astr) == 0:-1
-    @test find_first(r"H", astr) == 1:1
-    @test find_first(r"l", astr) == 3:3
-    @test find_first(r"\n", astr) == 14:14
-    @test find_next(r"H", astr, 2) == 0:-1
-    @test find_next(r"l", astr, 4) == 4:4
-    @test find_next(r"l", astr, 5) == 11:11
-    @test find_next(r"l", astr, 12) == 0:-1
-    @test find_next(r"\n", astr, 15) == 0:-1
-
-    for i = 1:lastindex(astr)
-        @test find_next(r"."s, astr, i) == i:i
-    end
-    # string forward search with a zero-char regex
-    for i = 1:lastindex(astr)
-        @test find_next(r"", astr, i) == i:i-1
-    end
-end
-
-@testset "Unicode Regex" begin
-    @test find_first(r"z", u8str) == 0:-1
-    @test find_first(r"∄", u8str) == 0:-1
-    @test find_first(r"∀", u8str) == 1:1
-    @test find_first(r"∀", u8str) == find_first(r"\u2200", u8str)
-    @test find_first(r"∃", u8str) == 13:13
-    @test find_first(r"x", u8str) == 26:26
-    @test find_first(r"ε", u8str) == 5:5
-
-    @test find_next(r"∀", u8str, 4) == 0:-1
-    @test find_next(r"∀", u8str, 4) == find_next(r"\u2200", u8str, 4)
-    @test find_next(r"∃", u8str, 16) == 0:-1
-    @test find_next(r"x", u8str, 27) == 43:43
-    @test find_next(r"x", u8str, 44) == 0:-1
-    @test find_next(r"ε", u8str, 7) == 54:54
-    @test find_next(r"ε", u8str, 56) == 0:-1
-
-    for i = 1:lastindex(u8str)
-        if isvalid(u8str,i)
-            @test find_next(r"."s, u8str, i) == i:i
-        end
-    end
-
-    for i = 1:lastindex(u8str)
-        # TODO: should regex search fast-forward invalid indices?
-        if isvalid(u8str,i)
-            @test find_next(r"", u8str, i) == i:i-1
-        end
-    end
-end
-
-@testset "string search with a two-char regex" begin
-    @test find_first(r"xx", fbbstr) == 0:-1
-    @test find_first(r"fo", fbbstr) == 1:2
-    @test find_first(r"oo", fbbstr) == 2:3
-    @test find_first(r"o,", fbbstr) == 3:4
-    @test find_first(r",b", fbbstr) == 4:5
-    @test find_first(r"az", fbbstr) == 10:11
-
-    @test find_next(r"fo", fbbstr, 3) == 0:-1
-    @test find_next(r"oo", fbbstr, 4) == 0:-1
-    @test find_next(r"o,", fbbstr, 5) == 0:-1
-    @test find_next(r",b", fbbstr, 6) == 8:9
-    @test find_next(r",b", fbbstr, 10) == 0:-1
-    @test find_next(r"az", fbbstr, 12) == 0:-1
-end
-
-@testset "contains with a String and Char needle" begin
-    @test contains("foo", "o")
-    @test contains("foo", 'o')
-end
-
-@testset "in operator" begin
-    @test_throws ErrorException "ab" ∈ "abc"
-end
-
-@testset "issue #15723" begin
-    @test find_first('(', "⨳(") == 4
-    @test find_next('(', "(⨳(", 2) == 5
-    @test find_last('(', "(⨳(") == 5
-    @test find_prev('(', "(⨳(", 2) == 1
-end
-
-#=
-@test @inferred findall('a', "éa") == [3]
-@test @inferred findall('€', "€€") == [1, 4]
-@test @inferred isempty(findall('é', ""))
-=#

--- a/test/substr.jl
+++ b/test/substr.jl
@@ -124,8 +124,8 @@ end
 # search and SubString (issue #5679)
 let str = "Hello, world!"
     u = SubString(str, 1, 5)
-    @test fnd(Rev, "World", u) == nothing
-    @test fnd(Rev, equalto('z'), u) == nothing
+    @test fnd(Rev, "World", u) == 0:-1
+    @test fnd(Rev, ==('z'), u) == 0:-1
     @test fnd(Rev, "ll", u) == 3:4
 end
 
@@ -280,14 +280,14 @@ end
             for c in ('X', 'δ', '\U0001d6a5')
                 s = convert(T, string(prefix, c, suffix))
                 r = reverse(s)
-                ri = fnd(Fwd, equalto(c), r)
+                ri = fnd(Fwd, ==(c), r)
                 @test c == s[reverseind(s, ri)] == r[ri]
                 s = convert(T, string(prefix, prefix, c, suffix, suffix))
                 pre = convert(T, prefix)
                 sb = SubString(s, nextind(pre, lastindex(pre)),
                                lastindex(convert(T, string(prefix, prefix, c, suffix))))
                 r = reverse(sb)
-                ri = fnd(Fwd, equalto(c), r)
+                ri = fnd(Fwd, ==(c), r)
                 @test c == sb[reverseind(sb, ri)] == r[ri]
             end
         end

--- a/test/substr.jl
+++ b/test/substr.jl
@@ -1,0 +1,341 @@
+#=
+SubString tests
+
+Copyright 2018 Gandalf Software, Inc., Scott P. Jones, and other contributors to the Julia language
+Licensed under MIT License, see LICENSE.md
+Based initially on julia/test/strings/types.jl
+=#
+
+function testsub(T, T(u8str))
+    _u8str = T(u8str)
+    u8str2 = _u8str^2
+    len_u8str = length(_u8str)
+    slen_u8str = length(_u8str)
+    len_u8str2 = length(u8str2)
+    slen_u8str2 = length(u8str2)
+    s1 = T("∀")
+    s2 = T("∀∀")
+
+    @test len_u8str2 == 2 * len_u8str
+    @test slen_u8str2 == 2 * slen_u8str
+
+    u8str2plain = String(u8str2)
+            
+    for i1 = 1:length(u8str2)
+        if !isvalid(u8str2, i1); continue; end
+        for i2 = i1:length(u8str2)
+            if !isvalid(u8str2, i2); continue; end
+            @test length(u8str2[i1:i2]) == length(u8str2plain[i1:i2])
+            @test length(u8str2[i1:i2]) == length(u8str2plain[i1:i2])
+            @test u8str2[i1:i2] == u8str2plain[i1:i2]
+        end
+    end
+
+    # tests that SubString of a single multibyte `Char` string, like "∀" which takes 3 bytes
+    # gives the same result as `getindex` (except that it is a veiw not a copy)
+    for idx in 0:1
+        @test SubString(s1, 1, idx) == s1[1:idx]
+    end
+
+    # Substring provided with invalid end index throws BoundsError
+    @test_throws StringIndexError SubString(s1, 1, 2)
+    @test_throws StringIndexError SubString(s1, 1, 3)
+    @test_throws BoundsError SubString(s1, 1, 4)
+
+    # Substring provided with invalid start index throws BoundsError
+    @test SubString(s2, 1:1) == s1
+    @test SubString(s2, 1:4) == s2
+    @test SubString(s2, 4:4) == s1
+    @test_throws StringIndexError SubString(s2, 1:2)
+    @test_throws StringIndexError SubString(s2, 1:5)
+    @test_throws StringIndexError SubString(s2, 2:4)
+    @test_throws BoundsError SubString(s2, 0:1)
+    @test_throws BoundsError SubString(s2, 0:4)
+    @test_throws BoundsError SubString(s2, 1:7)
+    @test_throws BoundsError SubString(s2, 4:7)
+
+    # tests for SubString of more than one multibyte `Char` string
+    # we are consistent with `getindex` for `String`
+    for idx in [0, 1, 4]
+        @test SubString(s2, 1, idx) == s2[1:idx]
+        @test SubString(s2, 4, idx) == s2[4:idx]
+    end
+
+    # index beyond lastindex(s2)
+    for idx in [2:3; 5:6]
+        @test_throws StringIndexError SubString(s2, 1, idx)
+    end
+    for idx in 7:8
+        @test_throws BoundsError SubString(s2, 1, idx)
+    end
+
+let str="tempus fugit"              #length(str)==12
+    ss=SubString(str,1,lastindex(str)) #match source string
+    @test length(ss)==length(str)
+
+    ss=SubString(str,1:lastindex(str))
+    @test length(ss)==length(str)
+
+    ss=SubString(str,1,0)    #empty SubString
+    @test length(ss)==0
+
+    ss=SubString(str,1:0)
+    @test length(ss)==0
+
+    @test_throws BoundsError SubString(str, 14, 20)  #start indexing beyond source string length
+    @test_throws BoundsError SubString(str, 10, 16)  #end indexing beyond source string length
+
+    @test_throws BoundsError SubString("", 1, 4)  #empty source string
+    @test_throws BoundsError SubString("", 1, 1)  #empty source string, identical start and end index
+    @test_throws BoundsError SubString("", 10, 12)
+    @test SubString("", 12, 10) == ""
+end
+
+@test SubString("foobar", big(1), big(3)) == "foo"
+
+let str = "aa\u2200\u2222bb"
+    u = SubString(str, 3, 6)
+    @test length(u) == 2
+    b = IOBuffer()
+    write(b, u)
+    @test String(take!(b)) == "\u2200\u2222"
+
+    @test_throws StringIndexError SubString(str, 4, 5)
+    @test_throws BoundsError next(u, 0)
+    @test_throws BoundsError next(u, 7)
+    @test_throws BoundsError getindex(u, 0)
+    @test_throws BoundsError getindex(u, 7)
+    @test_throws BoundsError getindex(u, 0:1)
+    @test_throws BoundsError getindex(u, 7:7)
+    @test reverseind(u, 1) == 4
+    @test typeof(Base.cconvert(Ptr{Int8}, u)) == SubString{String}
+    @test Base.cconvert(Ptr{Int8}, u) == u
+end
+
+let str = "føøbar"
+    @test_throws BoundsError SubString(str, 10, 10)
+    u = SubString(str, 4, 3)
+    @test length(u) == 0
+    b = IOBuffer()
+    write(b, u)
+    @test String(take!(b)) == ""
+end
+
+# search and SubString (issue #5679)
+let str = "Hello, world!"
+    u = SubString(str, 1, 5)
+    @test findlast("World", u) == nothing
+    @test findlast(equalto('z'), u) == nothing
+    @test findlast("ll", u) == 3:4
+end
+
+# SubString created from SubString
+let str = "Hello, world!"
+    u = SubString(str, 2, 5)
+    for idx in 1:4
+        @test SubString(u, 2, idx) == u[2:idx]
+        @test SubString(u, 2:idx) == u[2:idx]
+    end
+    @test_throws BoundsError SubString(u, 1, 10)
+    @test_throws BoundsError SubString(u, 1:10)
+    @test_throws BoundsError SubString(u, 20:30)
+    @test SubString(u, 20:15) == ""
+    @test_throws BoundsError SubString(u, -1:10)
+    @test SubString(u, -1, -10) == ""
+    @test SubString(SubString("123", 1, 2), -10, -20) == ""
+end
+
+# sizeof
+@test sizeof(SubString("abc\u2222def",4,4)) == 3
+
+# issue #3710
+@test prevind(SubString("{var}",2,4),4) == 3
+
+# issue #4183
+@test split(SubString("x", 2, 0), "y") == [""]
+
+# issue #6772
+@test parse(Float64, SubString("10",1,1)) === 1.0
+@test parse(Float64, SubString("1 0",1,1)) === 1.0
+@test parse(Float32, SubString("10",1,1)) === 1.0f0
+
+# issue #5870
+@test !contains(SubString("",1,0), Regex("aa"))
+@test contains(SubString("",1,0), Regex(""))
+
+# isvalid, length, prevind, nextind for SubString{String}
+let s = "lorem ipsum", sdict = Dict(
+    SubString(s, 1, 11)  => "lorem ipsum",
+    SubString(s, 1, 6)   => "lorem ",
+    SubString(s, 1, 0)   => "",
+    SubString(s, 2, 4)   => "ore",
+    SubString(s, 2, 11)  => "orem ipsum",
+    SubString(s, 15, 14) => "",
+)
+    for (ss, s) in sdict
+        @test ncodeunits(ss) == ncodeunits(s)
+        for i in -2:13
+            @test isvalid(ss, i) == isvalid(s, i)
+        end
+        for i in 1:ncodeunits(ss), j = i-1:ncodeunits(ss)
+            @test length(ss, i, j) == length(s, i, j)
+        end
+    end
+    for (ss, s) in sdict
+        @test length(ss) == length(s)
+        for i in 0:ncodeunits(ss), j = 0:length(ss)+1
+            @test prevind(ss, i+1, j) == prevind(s, i+1, j)
+            @test nextind(ss, i, j) == nextind(s, i, j)
+        end
+        @test_throws BoundsError prevind(s, 0)
+        @test_throws BoundsError prevind(ss, 0)
+        @test_throws BoundsError nextind(s, ncodeunits(ss)+1)
+        @test_throws BoundsError nextind(ss, ncodeunits(ss)+1)
+    end
+end
+
+# proper nextind/prevind/thisind for SubString{String}
+let rng = MersenneTwister(1), strs = ["∀∃∀"*String(rand(rng, UInt8, 40))*"∀∃∀",
+                                      String(rand(rng, UInt8, 50))]
+    for s in strs
+        a = 0
+        while !done(s, a)
+            a = nextind(s, a)
+            b = a - 1
+            while !done(s, b)
+                ss = SubString(s, a:b)
+                s2 = s[a:b]
+                @test ncodeunits(ss) == ncodeunits(s2)
+                for i in 0:ncodeunits(ss)+1
+                    @test thisind(ss, i) == thisind(s2, i)
+                end
+                for i in 0:ncodeunits(ss)
+                    @test nextind(ss, i) == nextind(s2, i)
+                    for j in 0:ncodeunits(ss)+5
+                        if j > 0 || isvalid(ss, i)
+                            @test nextind(ss, i, j) == nextind(s2, i, j)
+                        end
+                    end
+                end
+                for i in 1:ncodeunits(ss)+1
+                    @test prevind(ss, i) == prevind(s2, i)
+                    for j in 0:ncodeunits(ss)+5
+                        if j > 0 || isvalid(ss, i)
+                            @test prevind(ss, i, j) == prevind(s2, i, j)
+                        end
+                    end
+                end
+                b = nextind(s, b)
+            end
+        end
+    end
+end
+
+# for isvalid(SubString{String})
+let s = "Σx + βz - 2"
+    for i in -1:ncodeunits(s)+2
+        if checkbounds(Bool, s, i)
+            if isvalid(s, i)
+                ss = SubString(s, 1, i)
+                for j = 1:ncodeunits(ss)
+                    @test isvalid(ss, j) == isvalid(s, j)
+                end
+            else
+                @test_throws StringIndexError SubString(s, 1, i)
+            end
+        elseif i > 0
+            @test_throws BoundsError SubString(s, 1, i)
+        else
+            @test SubString(s, 1, i) == ""
+        end
+    end
+end
+
+let ss = SubString("hello", 1, 5)
+    @test length(ss, 1, 0) == 0
+    @test_throws BoundsError length(ss, 1, -1)
+    @test_throws BoundsError length(ss, 1, 6)
+    @test_throws BoundsError length(ss, 1, 10)
+    @test_throws BoundsError prevind(ss, 0, 1)
+    @test prevind(ss, 1, 1) == 0
+    @test prevind(ss, 6, 1) == 5
+    @test_throws BoundsError prevind(ss, 7, 1)
+    @test_throws BoundsError nextind(ss, -1, 1)
+    @test nextind(ss, 0, 1) == 1
+    @test nextind(ss, 5, 1) == 6
+    @test_throws BoundsError nextind(ss, 6, 1)
+end
+
+# length(SubString{String}) performance specialization
+let s = "|η(α)-ϕ(κ)| < ε"
+    @test length(SubString(s, 1, 0)) == length(s[1:0])
+    @test length(SubString(s, 4, 4)) == length(s[4:4])
+    @test length(SubString(s, 1, 7)) == length(s[1:7])
+    @test length(SubString(s, 4, 11)) == length(s[4:11])
+end
+
+@testset "reverseind" for T in (String, SubString, GenericString)
+    for prefix in ("", "abcd", "\U0001d6a4\U0001d4c1", "\U0001d6a4\U0001d4c1c", " \U0001d6a4\U0001d4c1")
+        for suffix in ("", "abcde", "\U0001d4c1β\U0001d6a4", "\U0001d4c1β\U0001d6a4c", " \U0001d4c1β\U0001d6a4")
+            for c in ('X', 'δ', '\U0001d6a5')
+                s = convert(T, string(prefix, c, suffix))
+                r = reverse(s)
+                ri = findfirst(equalto(c), r)
+                @test c == s[reverseind(s, ri)] == r[ri]
+                s = convert(T, string(prefix, prefix, c, suffix, suffix))
+                pre = convert(T, prefix)
+                sb = SubString(s, nextind(pre, lastindex(pre)),
+                               lastindex(convert(T, string(prefix, prefix, c, suffix))))
+                r = reverse(sb)
+                ri = findfirst(equalto(c), r)
+                @test c == sb[reverseind(sb, ri)] == r[ri]
+            end
+        end
+    end
+end
+
+@testset "reverseind of empty strings" begin
+    for s in ("",
+              SubString("", 1, 0),
+              SubString("ab", 1, 0),
+              SubString("ab", 2, 1),
+              SubString("ab", 3, 2),
+              GenericString(""))
+        @test reverseind(s, 0) == 1
+        @test reverseind(s, 1) == 0
+    end
+end
+
+## Cstring tests ##
+
+# issue #13974: comparison against pointers
+let
+    str = String("foobar")
+    ptr = pointer(str)
+    cstring = Cstring(ptr)
+    @test ptr == cstring
+    @test cstring == ptr
+
+    # convenient NULL string creation from Ptr{Cvoid}
+    nullstr = Cstring(C_NULL)
+
+    # Comparisons against NULL strings
+    @test ptr != nullstr
+    @test nullstr != ptr
+
+    # Short-hand comparison against C_NULL
+    @test nullstr == C_NULL
+    @test C_NULL == nullstr
+    @test cstring != C_NULL
+    @test C_NULL != cstring
+end
+end
+
+## SubString tests ##
+@testset "SubString tests" begin
+    for T in (UnicodeStringTypes..., ASCIIStr, LatinStr, UCS2Str)
+        @testset "Test $T" begin
+            testsub(T, T(u8str))
+        end
+    end
+end

--- a/test/substr.jl
+++ b/test/substr.jl
@@ -124,9 +124,9 @@ end
 # search and SubString (issue #5679)
 let str = "Hello, world!"
     u = SubString(str, 1, 5)
-    @test findlast("World", u) == nothing
-    @test findlast(equalto('z'), u) == nothing
-    @test findlast("ll", u) == 3:4
+    @test fnd(Rev, "World", u) == nothing
+    @test fnd(Rev, equalto('z'), u) == nothing
+    @test fnd(Rev, "ll", u) == 3:4
 end
 
 # SubString created from SubString
@@ -280,14 +280,14 @@ end
             for c in ('X', 'δ', '\U0001d6a5')
                 s = convert(T, string(prefix, c, suffix))
                 r = reverse(s)
-                ri = findfirst(equalto(c), r)
+                ri = fnd(Fwd, equalto(c), r)
                 @test c == s[reverseind(s, ri)] == r[ri]
                 s = convert(T, string(prefix, prefix, c, suffix, suffix))
                 pre = convert(T, prefix)
                 sb = SubString(s, nextind(pre, lastindex(pre)),
                                lastindex(convert(T, string(prefix, prefix, c, suffix))))
                 r = reverse(sb)
-                ri = findfirst(equalto(c), r)
+                ri = fnd(Fwd, equalto(c), r)
                 @test c == sb[reverseind(sb, ri)] == r[ri]
             end
         end

--- a/test/valid.jl
+++ b/test/valid.jl
@@ -1,5 +1,5 @@
 # Test starting and different position
-@test checkstring(UInt32[0x110000, 0x1f596], 2) == (1,0x10,1,0,0,0,0)
+@test check_string(UInt32[0x110000, 0x1f596], 2) == (1,0x10,1,0,0,0,0)
 
 # Test valid sequences
 for (seq, res) in (
@@ -39,5 +39,5 @@ for (seq, res) in (
     ([0x0ffff],            (1,8,0,1,0,0,0)),  # End of 3-byte range
     ([0x10000],            (1,16,1,0,0,0,0)), # \U10000, beginning of 4-byte range
     ([0x10ffff],           (1,16,1,0,0,0,0))) # \U10ffff, end of 4-byte range
-    @test checkstring(seq) == res
+    @test check_string(seq) == res
 end


### PR DESCRIPTION
`find(Fwd, ...)` and `find(Rev, ...)` replace `find_first, find_next, find_last, find_prev`
All names have `_` to separate words, and some names are changed for better readability:
`islower` -> `is_lowercase`
`isupper` -> `is_uppercase`
`isxdigit` -> `is_hex_digit`
`isprint`  -> `is_printable`
`isgraph` -> `is_graphic`
`isalnum` -> `is_alphanumeric`

Changes to match Julia PR 26436, i.e. `==(x)`, `in(x)`, `isequal(x)`.

