### PR TITLE
Link doesn't work

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 [![][travis-img]][travis-url]
 [![][codecov-img]][codecov-url]
 
-Strs.jl is a container for a number of different packages from [JuliaString.org](https://juliastring.org)
+Strs.jl is a container for a number of different packages from [JuliaString](https://github.com/JuliaString)
 It has two main goals:
 1) To be a drop-in replacement for the built-in `String` and `Char` types, adding types that are both faster and easier to use,
    that are also using for interfacing with other languages, and are safer to use.


### PR DESCRIPTION
Without https it does, but currently just redirects to this target. If you had plans for something else, this can be reverted.
[skip ci]